### PR TITLE
feat(guardrails): Upgrade Secrets Detection logic

### DIFF
--- a/benchmarks/secrets_benchmark.py
+++ b/benchmarks/secrets_benchmark.py
@@ -1,0 +1,166 @@
+import asyncio
+from typing import Any
+
+import weave
+from guardrails import Guard
+from guardrails.hub import SecretsPresent
+from llm_guard.input_scanners import Secrets
+from llm_guard.util import configure_logger
+
+from guardrails_genie.guardrails import GuardrailManager
+from guardrails_genie.guardrails.base import Guardrail
+from guardrails_genie.guardrails.secrets_detection import (
+    SecretsDetectionResponse,
+    SecretsDetectionSimpleResponse,
+    SecretsDetectionGuardrail,
+)
+from guardrails_genie.metrics import AccuracyMetric
+
+logger = configure_logger(log_level="ERROR")
+
+
+class GuardrailsAISecretsDetector(Guardrail):
+    validator: Any
+
+    def __init__(self):
+        validator = Guard().use(SecretsPresent, on_fail="fix")
+        super().__init__(validator=validator)
+
+    def scan(self, text: str) -> dict:
+        response = self.validator.validate(text)
+        if response.validation_summaries:
+            summary = response.validation_summaries[0]
+            return {
+                "has_secret": True,
+                "detected_secrets": {
+                    str(k): v
+                    for k, v in enumerate(
+                        summary.failure_reason.splitlines()[1:], start=1
+                    )
+                },
+                "explanation": summary.failure_reason,
+                "modified_prompt": response.validated_output,
+                "risk_score": 1.0,
+            }
+        else:
+            return {
+                "has_secret": False,
+                "detected_secrets": None,
+                "explanation": "No secrets detected in the text.",
+                "modified_prompt": response.validated_output,
+                "risk_score": 0.0,
+            }
+
+    @weave.op
+    def guard(
+        self,
+        prompt: str,
+        return_detected_secrets: bool = True,
+        **kwargs,
+    ) -> SecretsDetectionResponse | SecretsDetectionResponse:
+        results = self.scan(prompt)
+
+        if return_detected_secrets:
+            return SecretsDetectionResponse(
+                contains_secrets=results["has_secret"],
+                detected_secrets=results["detected_secrets"],
+                explanation=results["explanation"],
+                redacted_text=results["modified_prompt"],
+                risk_score=results["risk_score"],
+            )
+        else:
+            return SecretsDetectionSimpleResponse(
+                contains_secrets=not results["has_secret"],
+                explanation=results["explanation"],
+                redacted_text=results["modified_prompt"],
+                risk_score=results["risk_score"],
+            )
+
+
+class LLMGuardSecretsDetector(Guardrail):
+    validator: Any
+
+    def __init__(self):
+        validator = Secrets(redact_mode="all")
+        super().__init__(validator=validator)
+
+    def scan(self, text: str) -> dict:
+        sanitized_prompt, is_valid, risk_score = self.validator.scan(text)
+        if is_valid:
+            return {
+                "has_secret": not is_valid,
+                "detected_secrets": None,
+                "explanation": "No secrets detected in the text.",
+                "modified_prompt": sanitized_prompt,
+                "risk_score": risk_score,
+            }
+        else:
+            return {
+                "has_secret": not is_valid,
+                "detected_secrets": {},
+                "explanation": "This library does not return detected secrets.",
+                "modified_prompt": sanitized_prompt,
+                "risk_score": risk_score,
+            }
+
+    @weave.op
+    def guard(
+        self,
+        prompt: str,
+        return_detected_secrets: bool = True,
+        **kwargs,
+    ) -> SecretsDetectionResponse | SecretsDetectionResponse:
+        results = self.scan(prompt)
+        if return_detected_secrets:
+            return SecretsDetectionResponse(
+                contains_secrets=results["has_secret"],
+                detected_secrets=results["detected_secrets"],
+                explanation=results["explanation"],
+                redacted_text=results["modified_prompt"],
+                risk_score=results["risk_score"],
+            )
+        else:
+            return SecretsDetectionSimpleResponse(
+                contains_secrets=not results["has_secret"],
+                explanation=results["explanation"],
+                redacted_text=results["modified_prompt"],
+                risk_score=results["risk_score"],
+            )
+
+
+def main():
+    client = weave.init("parambharat/secrets-detection")
+    dataset = weave.ref("secrets-detection-benchmark:latest").get()
+    llm_guard_guardrail = LLMGuardSecretsDetector()
+    guardrails_ai_guardrail = GuardrailsAISecretsDetector()
+    guardrails_genie_guardrail = SecretsDetectionGuardrail()
+
+    all_guards = [
+        llm_guard_guardrail,
+        guardrails_ai_guardrail,
+        guardrails_genie_guardrail,
+    ]
+    evaluation = weave.Evaluation(
+        dataset=dataset.rows,
+        scorers=[AccuracyMetric()],
+    )
+
+    for guard in all_guards:
+        name = guard.__class__.__name__
+        guardrail_manager = GuardrailManager(
+            guardrails=[
+                guard,
+            ]
+        )
+
+        results = asyncio.run(
+            evaluation.evaluate(
+                guardrail_manager,
+                __weave={"display_name": f"{name}"},
+            )
+        )
+        print(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/guardrails_genie/guardrails/secrets_detection/__init__.py
+++ b/guardrails_genie/guardrails/secrets_detection/__init__.py
@@ -1,17 +1,15 @@
 from guardrails_genie.guardrails.secrets_detection.secrets_detection import (
-    DEFAULT_SECRETS_PATTERNS,
     SecretsDetectionGuardrail,
     SecretsDetectionSimpleResponse,
     SecretsDetectionResponse,
     REDACTION,
-    redact,
+    redact_value,
 )
 
 __all__ = [
-    "DEFAULT_SECRETS_PATTERNS",
     "SecretsDetectionGuardrail",
     "SecretsDetectionSimpleResponse",
     "SecretsDetectionResponse",
     "REDACTION",
-    "redact",
+    "redact_value",
 ]

--- a/guardrails_genie/guardrails/secrets_detection/secrets_detection.py
+++ b/guardrails_genie/guardrails/secrets_detection/secrets_detection.py
@@ -1,41 +1,30 @@
 import hashlib
 import json
+import os
 import pathlib
+import tempfile
 from enum import Enum
-from typing import Union, Optional
+from typing import Optional, Any
 
 import weave
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 from guardrails_genie.guardrails.base import Guardrail
-from guardrails_genie.regex_model import RegexModel
 
-
-def load_secrets_patterns() -> dict[str, list[str]]:
-    """
-    Load secret patterns from a JSONL file and return them as a dictionary.
-
-    Returns:
-        dict: A dictionary where keys are pattern names and values are lists of regex patterns.
-    """
-    default_patterns = {}
-    patterns = (
-        pathlib.Path(__file__).parent.absolute() / "secrets_patterns.jsonl"
-    ).read_text()
-
-    for pattern in patterns.splitlines():
-        pattern = json.loads(pattern)
-        default_patterns[pattern["name"]] = [rf"{pat}" for pat in pattern["patterns"]]
-    return default_patterns
-
-
-# Load default secret patterns from the JSONL file
-DEFAULT_SECRETS_PATTERNS = load_secrets_patterns()
+try:
+    from detect_secrets import SecretsCollection
+    from detect_secrets.settings import default_settings
+    import hyperscan
+except ImportError:
+    raise ImportError(
+        "The `detect-secrets` and the `hyperscan` packages are required for using the SecretsGuardrail. "
+        "Please install then by running `pip install detect-secrets hyperscan`."
+    )
 
 
 class REDACTION(str, Enum):
     """
-    Enum for different types of redaction methods.
+    Enum for different types of redaction modes.
     """
 
     REDACT_PARTIAL = "REDACT_PARTIAL"
@@ -44,31 +33,31 @@ class REDACTION(str, Enum):
     REDACT_NONE = "REDACT_NONE"
 
 
-def redact(text: str, matches: list[str], redaction_type: REDACTION) -> str:
+def redact_value(value: str, mode: str) -> str:
     """
-    Redact the given matches in the text based on the redaction type.
+    Redacts the given value based on the specified redaction mode.
 
     Args:
-        text (str): The input text to redact.
-        matches (list[str]): List of strings to be redacted.
-        redaction_type (REDACTION): The type of redaction to apply.
+        value (str): The string value to be redacted.
+        mode (str): The redaction mode to be applied. It can be one of the following:
+            - REDACTION.REDACT_PARTIAL: Partially redacts the value.
+            - REDACTION.REDACT_ALL: Fully redacts the value.
+            - REDACTION.REDACT_HASH: Redacts the value by hashing it.
+            - REDACTION.REDACT_NONE: No redaction is applied.
 
     Returns:
-        str: The redacted text.
+        str: The redacted value based on the specified mode.
     """
-    for match in matches:
-        if redaction_type == REDACTION.REDACT_PARTIAL:
-            replacement = "[REDACTED:]" + match[:2] + ".." + match[-2:] + "[:REDACTED]"
-        elif redaction_type == REDACTION.REDACT_ALL:
-            replacement = "[REDACTED:]" + ("*" * len(match)) + "[:REDACTED]"
-        elif redaction_type == REDACTION.REDACT_HASH:
-            replacement = (
-                "[REDACTED:]" + hashlib.md5(match.encode()).hexdigest() + "[:REDACTED]"
-            )
-        else:
-            replacement = match
-        text = text.replace(match, replacement)
-    return text
+    replacement = value
+    if mode == REDACTION.REDACT_PARTIAL:
+        replacement = "[REDACTED:]" + value[:2] + ".." + value[-2:] + "[:REDACTED]"
+    elif mode == REDACTION.REDACT_ALL:
+        replacement = "[REDACTED:]" + ("*" * len(value)) + "[:REDACTED]"
+    elif mode == REDACTION.REDACT_HASH:
+        replacement = (
+            "[REDACTED:]" + hashlib.md5(value.encode()).hexdigest() + "[:REDACTED]"
+        )
+    return replacement
 
 
 class SecretsDetectionSimpleResponse(BaseModel):
@@ -79,11 +68,13 @@ class SecretsDetectionSimpleResponse(BaseModel):
         contains_secrets (bool): Indicates if secrets were detected.
         explanation (str): Explanation of the detection result.
         redacted_text (Optional[str]): The redacted text if secrets were found.
+        risk_score (float): The risk score of the detection result. (0.0, 0.5, 1.0)
     """
 
     contains_secrets: bool
     explanation: str
     redacted_text: Optional[str] = None
+    risk_score: float = 0.0
 
     @property
     def safe(self) -> bool:
@@ -104,54 +95,329 @@ class SecretsDetectionResponse(SecretsDetectionSimpleResponse):
         detected_secrets (dict[str, list[str]]): Dictionary of detected secrets.
     """
 
-    detected_secrets: dict[str, list[str]]
+    detected_secrets: dict[str, Any] | None = None
+
+
+class SecretsInfo(BaseModel):
+    """
+    Model representing information about a detected secret.
+
+    Attributes:
+        secret (str): The detected secret value.
+        line_number (int): The line number where the secret was found.
+    """
+
+    secret: str
+    line_number: int
+
+
+class ScanResult(BaseModel):
+    """
+    Model representing the result of a secrets scan.
+
+    Attributes:
+        detected_secrets (dict[str, Any] | None): Dictionary of detected secrets, or None if no secrets were found.
+        modified_prompt (str): The modified prompt with secrets redacted.
+        has_secret (bool): Indicates if any secrets were detected.
+        risk_score (float): The risk score of the detection result.
+    """
+
+    detected_secrets: dict[str, Any] | None = None
+    modified_prompt: str
+    has_secret: bool
+    risk_score: float
+
+
+class DetectSecretsModel(weave.Model):
+    """
+    Model for detecting secrets using the detect-secrets library.
+    """
+
+    @staticmethod
+    def scan(text: str) -> dict[str, list[SecretsInfo]]:
+        """
+        Scans the given text for secrets using the detect-secrets library.
+
+        Args:
+            text (str): The text to scan for secrets.
+
+        Returns:
+            dict[str, list[SecretsInfo]]: A dictionary where the keys are secret types and the values are lists of SecretsInfo objects.
+        """
+        secrets = SecretsCollection()
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
+        temp_file.write(text.encode("utf-8"))
+        temp_file.close()
+
+        with default_settings():
+            secrets.scan_file(str(temp_file.name))
+
+        unique_secrets = {}
+        for file in secrets.files:
+            for found_secret in secrets[file]:
+                if found_secret.secret_value is None:
+                    continue
+
+                secret_type = found_secret.type
+                actual_secret = found_secret.secret_value
+                line_number = found_secret.line_number
+
+                if secret_type not in unique_secrets:
+                    unique_secrets[secret_type] = []
+
+                unique_secrets[secret_type].append(
+                    SecretsInfo(secret=actual_secret, line_number=line_number)
+                )
+
+        os.remove(temp_file.name)
+        return unique_secrets
+
+    @weave.op
+    def invoke(self, text: str) -> dict[str, list[SecretsInfo]]:
+        """
+        Invokes the scan method to detect secrets in the given text.
+
+        Args:
+            text (str): The text to scan for secrets.
+
+        Returns:
+            dict[str, list[SecretsInfo]]: A dictionary where the keys are secret types and the values are lists of SecretsInfo objects.
+        """
+        return self.scan(text)
+
+
+class HyperScanModel(weave.Model):
+    """
+    Model for detecting secrets using the Hyperscan library.
+    We use the Hyperscan library to scan for secrets using regex patterns.
+    The patterns are mined from https://github.com/mazen160/secrets-patterns-db
+    This model is used in conjunction with the DetectSecretsModel to improve the detection of secrets.
+    """
+
+    _db: Any = PrivateAttr()
+    _pattern_map: dict[str, str] = PrivateAttr()
+    only_high_confidence: bool = False
+    ids: list[str] = []
+
+    def _load_patterns(self) -> dict[str, str]:
+        """
+        Loads the patterns from a JSONL file.
+
+        Returns:
+            dict[str, str]: A dictionary where the keys are pattern names and the values are regex patterns.
+        """
+        patterns = (
+            pathlib.Path(__file__).parent.resolve() / "secrets_patterns.jsonl"
+        ).open()
+        patterns_list = [json.loads(line) for line in patterns]
+        if self.only_high_confidence:
+            patterns_list = [
+                pattern for pattern in patterns_list if pattern["confidence"] == "high"
+            ]
+        return {pattern["name"]: pattern["regex"] for pattern in patterns_list}
+
+    def __init__(self, **kwargs: Any):
+        """
+        Initializes the HyperScanModel instance.
+        """
+        super().__init__(**kwargs)
+
+    def model_post_init(self, __context: Any) -> None:
+        """
+        Post-initialization method to load patterns and compile the Hyperscan database.
+        """
+        self._pattern_map = self._load_patterns()
+        self.ids = list(self._pattern_map.keys())
+        expressions = [pattern.encode() for pattern in self._pattern_map.values()]
+        self._db = hyperscan.Database()
+        self._db.compile(expressions=expressions, ids=list(range(len(expressions))))
+
+    def scan(self, text: str) -> dict[str, list[SecretsInfo]]:
+        """
+        Scans the given text for secrets using the Hyperscan library.
+
+        Args:
+            text (str): The text to scan for secrets.
+
+        Returns:
+            dict[str, list[SecretsInfo]]: A dictionary where the keys are secret types and the values are lists of SecretsInfo objects.
+        """
+        unique_secrets = {}
+
+        def on_match(idx, start, end, flags, context):
+            """
+            Callback function for handling matches found by Hyperscan.
+
+            Args:
+                idx: The index of the matched pattern.
+                start: The start position of the match.
+                end: The end position of the match.
+                flags: The flags associated with the match.
+                context: The context provided to the scan method.
+            """
+            secret = context["text"][start:end]
+            line_number = context["line_number"]
+            current_match = unique_secrets.setdefault(self.ids[idx], [])
+
+            if not current_match or len(secret) > len(current_match[0].secret):
+                unique_secrets[self.ids[idx]] = [
+                    SecretsInfo(line_number=line_number, secret=secret)
+                ]
+
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            self._db.scan(
+                line.encode(),
+                match_event_handler=on_match,
+                context={"text": line, "line_number": line_no},
+            )
+
+        return unique_secrets
+
+    @weave.op
+    def invoke(self, text: str) -> dict[str, list[SecretsInfo]]:
+        """
+        Invokes the scan method to detect secrets in the given text.
+
+        Args:
+            text (str): The text to scan for secrets.
+
+        Returns:
+            dict[str, list[SecretsInfo]]: A dictionary where the keys are secret types and the values are lists of SecretsInfo objects.
+        """
+        return self.scan(text)
 
 
 class SecretsDetectionGuardrail(Guardrail):
     """
-    A guardrail for detecting secrets in text using regex patterns.
-    reference: SecretBench: A Dataset of Software Secrets
-    https://arxiv.org/abs/2303.06729
+    Guardrail class for secrets detection using both detect-secrets and Hyperscan models.
 
     Attributes:
-        regex_model (RegexModel): The regex model used for detection.
-        patterns (Union[dict[str, str], dict[str, list[str]]]): The patterns used for detection.
-        redaction (REDACTION): The type of redaction to apply.
+        redaction (REDACTION): The redaction mode to be applied.
+        _detect_secrets_model (Any): Instance of the DetectSecretsModel.
+        _hyperscan_model (Any): Instance of the HyperScanModel.
     """
 
-    regex_model: RegexModel
-    patterns: Union[dict[str, str], dict[str, list[str]]] = {}
     redaction: REDACTION
+    _detect_secrets_model: Any = PrivateAttr()
+    _hyperscan_model: Any = PrivateAttr()
+
+    def model_post_init(self, __context: Any) -> None:
+        """
+        Post-initialization method to initialize the detect-secrets and Hyperscan models.
+        """
+        self._detect_secrets_model = DetectSecretsModel()
+        self._hyperscan_model = HyperScanModel()
 
     def __init__(
         self,
-        use_defaults: bool = True,
         redaction: REDACTION = REDACTION.REDACT_ALL,
         **kwargs,
     ):
         """
-        Initialize the SecretsDetectionGuardrail.
+        Initializes the SecretsDetectionGuardrail instance.
 
         Args:
-            use_defaults (bool): Whether to use default patterns.
-            redaction (REDACTION): The type of redaction to apply.
+            redaction (REDACTION): The redaction mode to be applied. Defaults to REDACTION.REDACT_ALL.
             **kwargs: Additional keyword arguments.
         """
-        patterns = {}
-        if use_defaults:
-            patterns = DEFAULT_SECRETS_PATTERNS.copy()
-        if kwargs.get("patterns"):
-            patterns.update(kwargs["patterns"])
-
-        regex_model = RegexModel(patterns=patterns)
-
         super().__init__(
-            regex_model=regex_model,
-            patterns=patterns,
             redaction=redaction,
         )
 
-    @weave.op()
+    def get_modified_value(
+        self, unique_secrets: dict[str, Any], lines: list[str]
+    ) -> str:
+        """
+        Redacts the detected secrets in the given lines of text.
+
+        Args:
+            unique_secrets (dict[str, Any]): Dictionary of detected secrets.
+            lines (list[str]): List of lines of text.
+
+        Returns:
+            str: The modified text with secrets redacted.
+        """
+        for _, secrets_list in unique_secrets.items():
+            for secret_info in secrets_list:
+                secret = secret_info.secret
+                line_number = secret_info.line_number
+                lines[line_number - 1] = lines[line_number - 1].replace(
+                    secret, redact_value(secret, self.redaction)
+                )
+
+        modified_value = "\n".join(lines)
+        return modified_value
+
+    def get_scan_result(
+        self, unique_secrets: dict[str, list[SecretsInfo]], lines: list[str]
+    ) -> ScanResult | None:
+        """
+        Generates a ScanResult based on the detected secrets.
+
+        Args:
+            unique_secrets (dict[str, list[SecretsInfo]]): Dictionary of detected secrets.
+            lines (list[str]): List of lines of text.
+
+        Returns:
+            ScanResult | None: The scan result if secrets are detected, otherwise None.
+        """
+        if unique_secrets:
+            modified_value = self.get_modified_value(unique_secrets, lines)
+            detected_secrets = {
+                k: [i.secret for i in v] for k, v in unique_secrets.items()
+            }
+
+            return ScanResult(
+                **{
+                    "detected_secrets": detected_secrets,
+                    "modified_prompt": modified_value,
+                    "has_secret": True,
+                    "risk_score": 1.0,
+                }
+            )
+        return None
+
+    def scan(self, prompt: str) -> ScanResult:
+        """
+        Scans the given prompt for secrets using both detect-secrets and Hyperscan models.
+
+        Args:
+            prompt (str): The text to scan for secrets.
+
+        Returns:
+            ScanResult: The scan result with detected secrets and redacted text.
+        """
+        if prompt.strip() == "":
+            return ScanResult(
+                **{
+                    "detected_secrets": None,
+                    "modified_prompt": prompt,
+                    "has_secret": False,
+                    "risk_score": 0.0,
+                }
+            )
+
+        unique_secrets = self._detect_secrets_model.invoke(text=prompt)
+        results = self.get_scan_result(unique_secrets, prompt.splitlines())
+        if results:
+            return results
+
+        unique_secrets = self._hyperscan_model.invoke(text=prompt)
+        results = self.get_scan_result(unique_secrets, prompt.splitlines())
+        if results:
+            results.risk_score = 0.5
+            return results
+
+        return ScanResult(
+            **{
+                "detected_secrets": None,
+                "modified_prompt": prompt,
+                "has_secret": False,
+                "risk_score": 0.0,
+            }
+        )
+
+    @weave.op
     def guard(
         self,
         prompt: str,
@@ -159,40 +425,38 @@ class SecretsDetectionGuardrail(Guardrail):
         **kwargs,
     ) -> SecretsDetectionResponse | SecretsDetectionResponse:
         """
-        Check if the input prompt contains any secrets based on the regex patterns.
+        Guards the given prompt by scanning for secrets and optionally returning detected secrets.
 
         Args:
-            prompt (str): Input text to check for secrets.
-            return_detected_secrets (bool): If True, returns detailed secrets type information.
+            prompt (str): The text to scan for secrets.
+            return_detected_secrets (bool): Whether to return detected secrets in the response. Defaults to True.
+            **kwargs: Additional keyword arguments.
 
         Returns:
-            SecretsDetectionResponse or SecretsDetectionResponse: Detection results.
+            SecretsDetectionResponse | SecretsDetectionSimpleResponse: The response with scan results and redacted text.
         """
-        result = self.regex_model.check(prompt)
+        results = self.scan(prompt)
 
         explanation_parts = []
-        if result.matched_patterns:
+        if results.has_secret:
             explanation_parts.append("Found the following secrets in the text:")
-            for secret_type, matches in result.matched_patterns.items():
+            for secret_type, matches in results.detected_secrets.items():
                 explanation_parts.append(f"- {secret_type}: {len(matches)} instance(s)")
         else:
             explanation_parts.append("No secrets detected in the text.")
 
-        redacted_text = prompt
-        if result.matched_patterns:
-            for secret_type, matches in result.matched_patterns.items():
-                redacted_text = redact(redacted_text, matches, self.redaction)
-
         if return_detected_secrets:
             return SecretsDetectionResponse(
-                contains_secrets=not result.passed,
-                detected_secrets=result.matched_patterns,
+                contains_secrets=results.has_secret,
+                detected_secrets=results.detected_secrets,
                 explanation="\n".join(explanation_parts),
-                redacted_text=redacted_text,
+                redacted_text=results.modified_prompt,
+                risk_score=results.risk_score,
             )
         else:
             return SecretsDetectionSimpleResponse(
-                contains_secrets=not result.passed,
+                contains_secrets=not results.has_secret,
                 explanation="\n".join(explanation_parts),
-                redacted_text=redacted_text,
+                redacted_text=results.modified_prompt,
+                risk_score=results.risk_score,
             )

--- a/guardrails_genie/guardrails/secrets_detection/secrets_patterns.jsonl
+++ b/guardrails_genie/guardrails/secrets_detection/secrets_patterns.jsonl
@@ -1,869 +1,1603 @@
-{"name":"AWSKey","patterns":["(?:A3T[A-Z0-9]|ABIA|ACCA|AKIA|ASIA)[0-9A-Z]{16}","aws.{0,20}?(?:key|pwd|pw|password|pass|token).{0,20}?[\\'\\\"]([0-9a-zA-Z\/+]{40})[\\'\\\"]"]}
-{"name":"AbbysaleApi","patterns":["(?i)(?:abbysale)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{40})\\b"]}
-{"name":"AbstractApi","patterns":["(?i)(?:abstract)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"AbuseipdbApi","patterns":["(?i)(?:abuseipdb)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{80})\\b"]}
-{"name":"AccuweatherApi","patterns":["(?i)(?:accuweather)(?:.|[\\n\\r]){0,40}([a-z0-9A-Z\\%]{35})\\b"]}
-{"name":"AdafruitApi","patterns":["\\b(aio\\_[a-zA-Z0-9]{28})\\b"]}
-{"name":"AdafruitKey","patterns":["(?i)(?:adafruit)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9_-]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"AdobeSecret","patterns":["(?i)(?:adobe)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-f0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)\\b((p8e-)[a-z0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"AdobeStockApi","patterns":["(?i)(?:adobe)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"AdzunaApi","patterns":["(?i)(?:adzuna)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"AeroApi","patterns":["(?i)(?:aeroworkflow)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9^!]{20})\\b"]}
-{"name":"AgeSecretKey","patterns":["AGE-SECRET-KEY-1[QPZRY9X8GF2TVDW0S3JN54KHCE6MUA7L]{58}"]}
-{"name":"AgoraApi","patterns":["(?i)(?:agora)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"AhaApi","patterns":["(?i)(?:aha)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{64})\\b"]}
-{"name":"AirbrakeApi","patterns":["(?i)(?:airbrake)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{32})\\b"]}
-{"name":"AirshipApi","patterns":["(?i)(?:airship)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-zA-Z]{91})\\b"]}
-{"name":"AirtableApi","patterns":["\\b(key[a-zA-Z0-9_-]{14})\\b"]}
-{"name":"AirtableApiKey","patterns":["(?i)(?:airtable)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{17})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"AirvisualApi","patterns":["(?i)(?:airvisual)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"AlconostApi","patterns":["(?i)(?:alconost)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-z]{32})\\b"]}
-{"name":"AlegraApi","patterns":["(?i)(?:alegra)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{20})\\b"]}
-{"name":"AletheiaApi","patterns":["(?i)(?:aletheiaapi)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9]{32})\\b"]}
-{"name":"AlgoliaApi","patterns":["(?i)(?:algolia)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"AlgoliaApiKey","patterns":["(?i)\\b((LTAI)[a-z0-9]{20})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"AlibabaApi","patterns":["\\b([a-zA-Z0-9]{30})\\b"]}
-{"name":"AlibabaSecret","patterns":["(?i)(?:alibaba)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{30})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)\\b((LTAI)[a-z0-9]{20})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"AlienvaultApi","patterns":["(?i)(?:alienvault)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{64})\\b"]}
-{"name":"AllsportsApi","patterns":["(?i)(?:allsports)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{64})\\b"]}
-{"name":"AmadeusApi","patterns":["(?i)(?:amadeus)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{32})\\b"]}
-{"name":"AmazonMwsAuthToken","patterns":["amzn\\.mws\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"]}
-{"name":"AmbeeApi","patterns":["(?i)(?:ambee)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{64})\\b"]}
-{"name":"AmplitudeApi","patterns":["(?i)(?:amplitude)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{32})\\b"]}
-{"name":"AnypointApi","patterns":["\\b([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b"]}
-{"name":"ApactaApi","patterns":["(?i)(?:apacta)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"Api2CartApi","patterns":["(?i)(?:api2cart)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{32})\\b"]}
-{"name":"ApideckId","patterns":["(?i)(?:apideck)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{40})\\b"]}
-{"name":"ApideckKey","patterns":["\\b(sk_live_[a-z0-9A-Z-]{93})\\b"]}
-{"name":"ApiflashKey","patterns":["(?i)(?:apiflash)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"ApiflashUrl","patterns":["(?i)(?:apiflash)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9\\S]{21,30})\\b"]}
-{"name":"ApifonicaKey","patterns":["(?i)(?:apifonica)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{11}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b"]}
-{"name":"ApifyKey","patterns":["\\b(apify\\_api\\_[a-zA-Z-0-9]{36})\\b"]}
-{"name":"ApimaticKey","patterns":["(?i)(?:apimatic)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{3,20}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,5})\\b"]}
-{"name":"ApimaticPassword","patterns":["(?i)(?:apimatic)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-\\S]{8,32})\\b"]}
-{"name":"ApiscienceKey","patterns":["(?i)(?:apiscience)(?:.|[\\n\\r]){0,40}\\b([a-bA-Z0-9\\S]{22})\\b"]}
-{"name":"ApitemplateKey","patterns":["(?i)(?:apitemplate)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{39})\\b"]}
-{"name":"ApolloApiKey","patterns":["(?i)(?:apollo)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{22})\\b"]}
-{"name":"AppcuesApiId","patterns":["(?i)(?:appcues)(?:.|[\\n\\r]){0,40}\\b([0-9]{5})\\b"]}
-{"name":"AppcuesApiKey","patterns":["(?i)(?:appcues)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"AppcuesApiUser","patterns":["(?i)(?:appcues)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{39})\\b"]}
-{"name":"AppfollowApiKey","patterns":["(?i)(?:appfollow)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{20})\\b"]}
-{"name":"AppsynergyApiKey","patterns":["(?i)(?:appsynergy)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{64})\\b"]}
-{"name":"ApptivoApiKey","patterns":["(?i)(?:apptivo)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"Artifactory","patterns":["(?:\\s|=|:|\"|^)AKC[a-zA-Z0-9]{10,}(?:\\s|\"|$)","(?:\\s|=|:|\"|^)AP[\\dABCDEF][a-zA-Z0-9]{8,}(?:\\s|\"|$)"]}
-{"name":"ArtifactoryApiKey","patterns":["\\b([a-zA-Z0-9]{73})"]}
-{"name":"ArtifactoryApiUrl","patterns":["\\b([A-Za-z0-9](?:[A-Za-z0-9\\-]{0,61}[A-Za-z0-9])\\.jfrog\\.io)"]}
-{"name":"ArtsyApiKey","patterns":["(?i)(?:artsy)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{32})\\b"]}
-{"name":"AsanaAccessToken","patterns":["(?i)(?:asana)(?:.|[\\n\\r]){0,40}\\b([0-9]{1,}\\\/[0-9]{16,}:[A-Za-z0-9]{32,})\\b"]}
-{"name":"AsanaApiKey","patterns":["(?i)(?:asana)(?:.|[\\n\\r]){0,40}\\b([a-z\\\/:0-9]{51})\\b"]}
-{"name":"AsanaSecret","patterns":["(?i)(?:asana)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([0-9]{16})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:asana)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"AssemblyaiApiKey","patterns":["(?i)(?:assemblyai)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"AteraApiKey","patterns":["(?i)(?:atera)(?:.|[\\n\\r]){0,40}\\b([[0-9a-z]{32})\\b"]}
-{"name":"AtlassianApiToken","patterns":["(?i)(?:atlassian|confluence|jira)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{24})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"AuddApiKey","patterns":["(?i)(?:audd)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{32})\\b"]}
-{"name":"Auth0ApiToken","patterns":["(?i)(?:auth0)(?:.|[\\n\\r]){0,40}\\b(ey[a-zA-Z0-9._-]+)\\b"]}
-{"name":"Auth0DomainUrl","patterns":["([a-zA-Z0-9\\-]{2,16}\\.[a-zA-Z0-9_-]{2,3}\\.auth0\\.com)"]}
-{"name":"Auth0OauthClientId","patterns":["(?i)(?:auth0)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_-]{32,60})\\b"]}
-{"name":"Auth0OauthClientSecret","patterns":["\\b([a-zA-Z0-9_-]{64,})\\b"]}
-{"name":"Auth0OauthDomainUrl","patterns":["\\b([a-zA-Z0-9][a-zA-Z0-9._-]*auth0\\.com)\\b"]}
-{"name":"AuthressAccessKey","patterns":["(?i)\\b((?:sc|ext|scauth|authress)_[a-z0-9]{5,30}\\.[a-z0-9]{4,6}\\.acc[_-][a-z0-9-]{10,32}\\.[a-z0-9+\/_=-]{30,120})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"AutodeskApiKey","patterns":["(?i)(?:autodesk)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{32})\\b"]}
-{"name":"AutodeskSecret","patterns":["(?i)(?:autodesk)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{16})\\b"]}
-{"name":"AutokloseApiKey","patterns":["(?i)(?:autoklose)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-]{32})\\b"]}
-{"name":"AutopilotApiKey","patterns":["(?i)(?:autopilot)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{32})\\b"]}
-{"name":"AvazaApiToken","patterns":["(?i)(?:avaza)(?:.|[\\n\\r]){0,40}\\b([0-9]+-[0-9a-f]{40})\\b"]}
-{"name":"AviationstackApiKey","patterns":["(?i)(?:aviationstack)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"AwsApiId","patterns":["\\b((?:AKIA|ABIA|ACCA|ASIA)[0-9A-Z]{16})\\b"]}
-{"name":"AwsApiSecret","patterns":["\\b([A-Za-z0-9+\/]{40})[ \\r\\n'\"\\x60]"]}
-{"name":"AxonautApiKey","patterns":["(?i)(?:axonaut)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"AylienApiKey","patterns":["(?i)(?:aylien)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"AyrshareApiKey","patterns":["(?i)(?:ayrshare)(?:.|[\\n\\r]){0,40}\\b([A-Z]{7}-[A-Z0-9]{7}-[A-Z0-9]{7}-[A-Z0-9]{7})\\b"]}
-{"name":"AzureClientSecret","patterns":["(?i)(%s).{0,20}([a-z0-9_\\.\\-~]{34})"]}
-{"name":"AzureKeyId","patterns":["(?i)(%s).{0,20}([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})"]}
-{"name":"AzureStorageKey","patterns":["AccountKey=[a-zA-Z0-9+\\\/=]{88}"]}
-{"name":"BannerbearApiKey","patterns":["(?i)(?:bannerbear)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{22}tt)\\b"]}
-{"name":"BaremetricsApiKey","patterns":["(?i)(?:baremetrics)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]{25})\\b"]}
-{"name":"Base-ApiIoApiKey","patterns":["(?i)(?:baseapi|base-api)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b"]}
-{"name":"BasicAuth","patterns":[":\/\/[^:\/\\?\\#\\[\\]@!\\$\\&'\\(\\)\\*\\+,;=\\s]+:([^:\/\\?\\#\\[\\]@!\\$\\&'\\(\\)\\*\\+,;=\\s]+)@"]}
-{"name":"BeamerApiKey","patterns":["(?i)(?:beamer)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_+\/]{45}=)"]}
-{"name":"BeamerApiToken","patterns":["(?i)(?:beamer)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(b_[a-z0-9=_\\-]{44})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"BeeboleApiKey","patterns":["(?i)(?:beebole)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{40})\\b"]}
-{"name":"BesnappyApiKey","patterns":["(?i)(?:besnappy)(?:.|[\\n\\r]){0,40}\\b([a-f0-9]{64})\\b"]}
-{"name":"BesttimeApiKey","patterns":["(?i)(?:besttime)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z_]{36})\\b"]}
-{"name":"BillomatApiKey","patterns":["(?i)(?:billomat)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"BitbarApiKey","patterns":["(?i)(?:bitbar)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"Bitbucket","patterns":["(?i)(?:bitbucket)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9=_\\-]{64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:bitbucket)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"BitcoinaverageApiKey","patterns":["(?i)(?:bitcoinaverage)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{43})\\b"]}
-{"name":"BitfinexApiKey","patterns":["(?i)(?:bitfinex)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{43})\\b"]}
-{"name":"BitlyAccessToken","patterns":["(?i)(?:bitly)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{40})\\b"]}
-{"name":"BitmexApiKey","patterns":["(?i)(?:bitmex)(?:.|[\\n\\r]){0,40}([ \\r\\n]{1}[0-9a-zA-Z\\-\\_]{24}[ \\r\\n]{1})"]}
-{"name":"BitmexApiSecret","patterns":["(?i)(?:bitmex)(?:.|[\\n\\r]){0,40}([ \\r\\n]{1}[0-9a-zA-Z\\-\\_]{48}[ \\r\\n]{1})"]}
-{"name":"Bittrex","patterns":["(?i)(?:bittrex)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"BlablacarBusApiKey","patterns":["(?i)(?:blablabus)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{22})\\b"]}
-{"name":"BlazemeterApiKey","patterns":["(?i)(?:blazemeter|runscope)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b"]}
-{"name":"BlitappApiKey","patterns":["(?i)(?:blitapp)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_-]{39})\\b"]}
-{"name":"BloggerApiKey","patterns":["(?i)(?:blogger)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z-]{39})\\b"]}
-{"name":"BombbombApiKey","patterns":["(?i)(?:bombbomb)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-._]{704})\\b"]}
-{"name":"BoostnoteApiKey","patterns":["(?i)(?:boostnote)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{64})\\b"]}
-{"name":"BorgbaseApiKey","patterns":["(?i)(?:borgbase)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9\/_.-]{148,152})\\b"]}
-{"name":"BrandfetchApiKey","patterns":["(?i)(?:brandfetch)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{40})\\b"]}
-{"name":"BrowserstackApiKey","patterns":["(?i)(?:browserstack)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{20})\\b"]}
-{"name":"BrowserstackUserId","patterns":["(?i)(?:browserstack)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{3,10}_[0-9a-zA-Z]{6})\\b"]}
-{"name":"BrowshotApiKey","patterns":["(?i)(?:browshot)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{28})\\b"]}
-{"name":"BuddynsApiKey","patterns":["(?i)(?:buddyns)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{40})\\b"]}
-{"name":"BugherdApiKey","patterns":["(?i)(?:bugherd)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{22})\\b"]}
-{"name":"BugsnagApiKey","patterns":["(?i)(?:bugsnag)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b"]}
-{"name":"BuildkiteApiKey","patterns":["(?i)(?:buildkite)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{40})\\b"]}
-{"name":"BulbulApiKey","patterns":["(?i)(?:bulbul)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"BulksmsApiKey","patterns":["(?i)(?:bulksms)(?:.|[\\n\\r]){0,40}\\b([a-fA-Z0-9*]{29})\\b"]}
-{"name":"ButtercmsApiKey","patterns":["(?i)(?:buttercms)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{40})\\b"]}
-{"name":"CaflouApiKey","patterns":["(?i)(?:caflou)(?:.|[\\n\\r]){0,40}\\b([a-bA-Z0-9\\S]{155})\\b"]}
-{"name":"CalendarificApiKey","patterns":["(?i)(?:calendarific)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{40})\\b"]}
-{"name":"CalendlyApiKey","patterns":["(?i)(?:calendly)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{20}.[a-zA-Z-0-9]{171}.[a-zA-Z-0-9_]{43})\\b"]}
-{"name":"CalorieninjaApiKey","patterns":["(?i)(?:calorieninja)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{40})\\b"]}
-{"name":"CampaynApiKey","patterns":["(?i)(?:campayn)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{64})\\b"]}
-{"name":"CannyApiKey","patterns":["(?i)(?:canny)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[0-9]{4}-[a-z0-9]{12})\\b"]}
-{"name":"CapsulecrmApiKey","patterns":["(?i)(?:capsulecrm)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-._+=]{64})\\b"]}
-{"name":"CaptaindataApiKey","patterns":["(?i)(?:captaindata)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{64})\\b"]}
-{"name":"CaptaindataApiProjectId","patterns":["(?i)(?:captaindata)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{8}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{12})\\b"]}
-{"name":"CarboninterfaceApiKey","patterns":["(?i)(?:carboninterface)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{21})\\b"]}
-{"name":"CashboardApiKey","patterns":["(?i)(?:cashboard)(?:.|[\\n\\r]){0,40}\\b([0-9A-Z]{3}-[0-9A-Z]{3}-[0-9A-Z]{3}-[0-9A-Z]{3})\\b"]}
-{"name":"CaspioApiDomain","patterns":["(?i)(?:caspio)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{8})\\b"]}
-{"name":"CaspioApiKey","patterns":["(?i)(?:caspio)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{50})\\b"]}
-{"name":"CensysApiKey","patterns":["(?i)(?:censys)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"CentralstationApiKey","patterns":["(?i)(?:centralstation)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{30})\\b"]}
-{"name":"CexioApiKey","patterns":["(?i)(?:cexio|cex.io)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{24,27})\\b"]}
-{"name":"ChartmogulApiKey","patterns":["(?i)(?:chartmogul)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"ChatbotApiKey","patterns":["(?i)(?:chatbot)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]{32})\\b"]}
-{"name":"ChatfuelApiKey","patterns":["(?i)(?:chatfuel)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{128})\\b"]}
-{"name":"ChecioApiKey","patterns":["(?i)(?:checio)(?:.|[\\n\\r]){0,40}\\b(pk_[a-z0-9]{45})\\b"]}
-{"name":"ChecklyhqApiKey","patterns":["(?i)(?:checklyhq)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"CheckoutApiId","patterns":["(?i)(?:checkout)(?:.|[\\n\\r]){0,40}\\b(cus_[0-9a-zA-Z]{26})\\b"]}
-{"name":"CheckoutApiKey","patterns":["(?i)(?:checkout)(?:.|[\\n\\r]){0,40}\\b((sk_|sk_test_)[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\\b"]}
-{"name":"CheckvistApiKey","patterns":["(?i)(?:checkvist)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{14})\\b"]}
-{"name":"CiceroApiKey","patterns":["(?i)(?:cicero)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{40})\\b"]}
-{"name":"CircelciApiKey","patterns":["(?i)(?:circle)(?:.|[\\n\\r]){0,40}([a-fA-F0-9]{40})"]}
-{"name":"ClarifaiApiKey","patterns":["(?i)(?:clarifai)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"ClearbitApiKey","patterns":["(?i)(?:clearbit)(?:.|[\\n\\r]){0,40}\\b([0-9a-z_]{35})\\b"]}
-{"name":"ClickhelpApiKey","patterns":["(?i)(?:clickhelp)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{24})\\b"]}
-{"name":"ClickhelpServerUrl","patterns":["\\b([0-9A-Za-z]{3,20}.try.clickhelp.co)\\b"]}
-{"name":"ClicksendsmsApiKey","patterns":["\\b([0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12})\\b"]}
-{"name":"ClickupPersonalToken","patterns":["(?i)(?:clickup)(?:.|[\\n\\r]){0,40}\\b(pk_[0-9]{8}_[0-9A-Z]{32})\\b"]}
-{"name":"CliengoApiKey","patterns":["(?i)(?:cliengo)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{8}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{12})\\b"]}
-{"name":"ClinchpadApiKey","patterns":["(?i)(?:clinchpad)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"ClockifyApiKey","patterns":["(?i)(?:clockify)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{48})\\b"]}
-{"name":"ClockworkApiSecret","patterns":["(?i)(?:clockwork|textanywhere)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{24})\\b"]}
-{"name":"ClockworkApiUserKey","patterns":["(?i)(?:clockwork|textanywhere)(?:.|[\\n\\r]){0,40}\\b([0-9]{5})\\b"]}
-{"name":"ClojarsApiToken","patterns":["(?i)(CLOJARS_)[a-z0-9]{60}"]}
-{"name":"ClosecrmApiKey","patterns":["\\b(api_[a-z0-9A-Z.]{45})\\b"]}
-{"name":"Cloudant","patterns":["(?:(?<=\\W)|(?<=^))(?:\\[|)(?:\"|\\'|)(?:cloudant|cl|clou)(?:_|-|)(?:api|)(?:key|pwd|pw|password|pass|token)(?:\"|\\'|)(?:\\]|)(?: *)(?:=|:|:=|=>| +|::)(?: *)(?:\"|\\'|)([0-9a-f]{64})(?:\"|\\'|)","(?:(?<=\\W)|(?<=^))(?:\\[|)(?:\"|\\'|)(?:cloudant|cl|clou)(?:_|-|)(?:api|)(?:key|pwd|pw|password|pass|token)(?:\"|\\'|)(?:\\]|)(?: *)(?:=|:|:=|=>| +|::)(?: *)(?:\"|\\'|)([a-z]{24})(?:\"|\\'|)","(?:https?\\:\\\/\\\/)[\\w\\-]+\\:([0-9a-f]{64})\\@[\\w\\-]+\\.cloudant\\.com","(?:https?\\:\\\/\\\/)[\\w\\-]+\\:([a-z]{24})\\@[\\w\\-]+\\.cloudant\\.com"]}
-{"name":"CloudelementsApiKey","patterns":["(?i)(?:cloudelements)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{43})\\b"]}
-{"name":"CloudflareApiKey","patterns":["(?i)(?:cloudflare)(?:.|[\\n\\r]){0,40}([A-Za-z0-9_-]{37})"]}
-{"name":"CloudflareApiToken","patterns":["(?i)(?:cloudflare)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{40})\\b"]}
-{"name":"CloudflareCertificateKey","patterns":["(?i)(?:cloudflare)(?:.|[\\n\\r]){0,40}\\b(v[A-Za-z0-9._-]{173,})\\b"]}
-{"name":"CloudimageApiKey","patterns":["(?i)(?:cloudimage)(?:.|[\\n\\r]){0,40}\\b([a-z0-9_]{30})\\b"]}
-{"name":"CloudmersiveApiKey","patterns":["(?i)(?:cloudmersive)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"CloudplanApiKey","patterns":["(?i)(?:cloudplan)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9-]{32})\\b"]}
-{"name":"CloudsmithApiKey","patterns":["(?i)(?:cloudsmith)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{40})\\b"]}
-{"name":"CloverlyApiKey","patterns":["(?i)(?:cloverly)(?:.|[\\n\\r]){0,40}\\b([a-z0-9:_]{28})\\b"]}
-{"name":"ClozeApiKey","patterns":["(?i)(?:cloze)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{32})\\b"]}
-{"name":"ClustdocApiKey","patterns":["(?i)(?:clustdoc)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{60})\\b"]}
-{"name":"CodacyApiKey","patterns":["(?i)(?:codacy)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{20})\\b"]}
-{"name":"CodecovAccessToken","patterns":["(?i)(?:codecov)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"CodequiryApiKey","patterns":["(?i)(?:codequiry)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{64})\\b"]}
-{"name":"CoinApiKey","patterns":["(?i)(?:coinapi)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9-]{36})\\b"]}
-{"name":"CoinbaseAccessToken","patterns":["(?i)(?:coinbase)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9_-]{64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"CoinbaseApiKey","patterns":["(?i)(?:coinbase)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{64})\\b"]}
-{"name":"CoinlayerApiKey","patterns":["(?i)(?:coinlayer)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"CoinlibApiKey","patterns":["(?i)(?:coinlib)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{16})\\b"]}
-{"name":"Collect2ApiKey","patterns":["(?i)(?:collect2)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b"]}
-{"name":"ColumnApiKey","patterns":["(?i)(?:column)(?:.|[\\n\\r]){0,40}\\b((?:test|live)_[a-zA-Z0-9]{27})\\b"]}
-{"name":"CommercejsApiKey","patterns":["(?i)(?:commercejs)(?:.|[\\n\\r]){0,40}\\b([a-z0-9_]{48})\\b"]}
-{"name":"CommoditiesApiKey","patterns":["(?i)(?:commodities)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{60})\\b"]}
-{"name":"CompanyhubApiKey","patterns":["(?i)(?:companyhub)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{20})\\b"]}
-{"name":"Confluent","patterns":["(?i)(?:confluent)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{16})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:confluent)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"ConfluentApiKey","patterns":["(?i)(?:confluent)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{16})\\b"]}
-{"name":"ConfluentApiSecret","patterns":["(?i)(?:confluent)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{64})\\b"]}
-{"name":"ContentfulApiPersonalToken","patterns":["\\b([CFPAT\\-a-zA-Z-0-9]{49})\\b"]}
-{"name":"ContentfulApiToken","patterns":["(?i)(?:contentful)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9=_\\-]{43})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"ConversiontoolsApiKey","patterns":["(?i)(?:conversiontools)(?:.|[\\n\\r]){0,40}\\b(ey[a-zA-Z0-9_.]{157,165})\\b"]}
-{"name":"ConvertapiKey","patterns":["(?i)(?:convertapi)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{16})\\b"]}
-{"name":"ConvertkitApiKey","patterns":["(?i)(?:convertkit)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z_]{22})\\b"]}
-{"name":"ConvierApiKey","patterns":["(?i)(?:convier)(?:.|[\\n\\r]){0,40}\\b([0-9]{2}\\|[a-zA-Z0-9]{40})\\b"]}
-{"name":"CopperApiKey","patterns":["(?i)(?:copper)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"CountrylayerApiKey","patterns":["(?i)(?:countrylayer)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"CourierApiKey","patterns":["(?i)(?:courier)(?:.|[\\n\\r]){0,40}\\b(pk\\_[a-zA-Z0-9]{1,}\\_[a-zA-Z0-9]{28})\\b"]}
-{"name":"CoverallsApiKey","patterns":["(?i)(?:coveralls)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-]{37})\\b"]}
-{"name":"CraftmypdfApiKey","patterns":["(?i)(?:craftmypdf)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{35})\\b"]}
-{"name":"CrossbrowsertestingApiKey","patterns":["(?i)(?:crossbrowsertesting)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{16})\\b"]}
-{"name":"CrowdinApiKey","patterns":["(?i)(?:crowdin)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{80})\\b"]}
-{"name":"CryptocompareApiKey","patterns":["(?i)(?:cryptocompare)(?:.|[\\n\\r]){0,40}\\b([a-z-0-9]{64})\\b"]}
-{"name":"CurrencycloudApiKey","patterns":["(?i)(?:currencycloud)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{64})\\b"]}
-{"name":"CurrencyfreaksApiKey","patterns":["(?i)(?:currencyfreaks)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"CurrencylayerApiKey","patterns":["(?i)(?:currencylayer)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"CurrencyscoopApiKey","patterns":["(?i)(?:currencyscoop)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"CurrentsApiKey","patterns":["(?i)(?:currentsapi)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9\\S]{48})\\b"]}
-{"name":"CustomerioApiKey","patterns":["(?i)(?:customer)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{20})\\b"]}
-{"name":"CustomguruApiKey","patterns":["(?i)(?:guru)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{30})\\b"]}
-{"name":"D7NetworkApiKey","patterns":["(?i)(?:d7network)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9\\W\\S]{23}\\=)"]}
-{"name":"DailycoApiKey","patterns":["(?i)(?:daily)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{64})\\b"]}
-{"name":"DandelionApiKey","patterns":["(?i)(?:dandelion)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"DareboostApiKey","patterns":["(?i)(?:dareboost)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{60})\\b"]}
-{"name":"DatabricksApiToken","patterns":["(?i)\\b(dapi[a-h0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"DatadogAccessToken","patterns":["(?i)(?:datadog)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{40})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"DatadogApiKey","patterns":["(?i)(?:datadog)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{40})\\b"]}
-{"name":"DatafireApiKey","patterns":["(?i)(?:datafire)(?:.|[\\n\\r]){0,40}\\b([a-z0-9\\S]{175,190})\\b"]}
-{"name":"DebounceApiKey","patterns":["(?i)(?:debounce)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{13})\\b"]}
-{"name":"DeepaiApiKey","patterns":["(?i)(?:deepai)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"DeepgramApiKey","patterns":["(?i)(?:deepgram)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{40})\\b"]}
-{"name":"DefinedNetworkingApiToken","patterns":["(?i)(?:dnkey)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(dnkey-[a-z0-9=_\\-]{26}-[a-z0-9=_\\-]{52})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"DelightedApiKey","patterns":["(?i)(?:delighted)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{32})\\b"]}
-{"name":"DeputyApiKey","patterns":["(?i)(?:deputy)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"DetectifyApiKey","patterns":["(?i)(?:detectify)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"DetectlanguageApiKey","patterns":["(?i)(?:detectlanguage)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"DfuseApiKey","patterns":["\\b(web\\_[0-9a-z]{32})\\b"]}
-{"name":"DiffbotApiKey","patterns":["(?i)(?:diffbot)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"DiggernautApiKey","patterns":["(?i)(?:diggernaut)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{40})\\b"]}
-{"name":"Digitalocean","patterns":["(?i)\\b(doo_v1_[a-f0-9]{64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)\\b(dop_v1_[a-f0-9]{64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)\\b(dor_v1_[a-f0-9]{64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"DigitaloceanApiToken","patterns":["(?i)(?:digitalocean)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{64})\\b"]}
-{"name":"Discord","patterns":["(?i)(?:discord)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([0-9]{18})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:discord)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-f0-9]{64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:discord)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9=_\\-]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"DiscordApiToken","patterns":["(?i)(?:discord)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{24}\\.[A-Za-z0-9_-]{6}\\.[A-Za-z0-9_-]{27})\\b"]}
-{"name":"DiscordBotToken","patterns":["[MNO][a-zA-Z\\d_-]{23,25}\\.[a-zA-Z\\d_-]{6}\\.[a-zA-Z\\d_-]{27}"]}
-{"name":"DiscordWebHook","patterns":["(https:\\\/\\\/discord\\.com\\\/api\\\/webhooks\\\/[0-9]{18}\\\/[0-9a-zA-Z-]{68})"]}
-{"name":"DisqusApiKey","patterns":["(?i)(?:disqus)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{64})\\b"]}
-{"name":"DittoApiKey","patterns":["(?i)(?:ditto)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{8}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{12}\\.[a-z0-9]{40})\\b"]}
-{"name":"DnscheckApiKey","patterns":["(?i)(?:dnscheck)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{32})\\b"]}
-{"name":"DocumoApiKey","patterns":["\\b(ey[a-zA-Z0-9]{34}.ey[a-zA-Z0-9]{154}.[a-zA-Z0-9_-]{43})\\b"]}
-{"name":"DopplerApiKey","patterns":["\\b(dp\\.pt\\.[a-zA-Z0-9]{43})\\b"]}
-{"name":"DopplerApiToken","patterns":["(?i)dp\\.pt\\.[a-z0-9]{43}"]}
-{"name":"DotmailerApiKey","patterns":["(?i)(?:dotmailer)(?:.|[\\n\\r]){0,40}\\b(apiuser-[a-z0-9]{12}@apiconnector.com)\\b"]}
-{"name":"DotmailerPassword","patterns":["(?i)(?:dotmailer)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9\\S]{8,24})\\b"]}
-{"name":"DovicoApiKey","patterns":["(?i)(?:dovico)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32}\\.[0-9a-z]{1,}\\b)"]}
-{"name":"DronahqApiKey","patterns":["(?i)(?:dronahq)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{50})\\b"]}
-{"name":"DroneciAccessToken","patterns":["(?i)(?:droneci)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"DroneciApiKey","patterns":["(?i)(?:droneci)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"Dropbox","patterns":["(?i)(?:dropbox)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\\-_=]{43})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:dropbox)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{15})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:dropbox)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(sl\\.[a-z0-9\\-=_]{135})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"DropboxApiKey","patterns":["\\b(sl\\.[A-Za-z0-9\\-\\_]{130,140})\\b"]}
-{"name":"DuffelApiToken","patterns":["(?i)duffel_(test|live)_[a-z0-9_\\-=]{43}"]}
-{"name":"DwollaApiKey","patterns":["(?i)(?:dwolla)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{50})\\b"]}
-{"name":"DynalistApiKey","patterns":["(?i)(?:dynalist)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-_]{128})\\b"]}
-{"name":"DynatraceApiToken","patterns":["(?i)dt0c01\\.[a-z0-9]{24}\\.[a-z0-9]{64}"]}
-{"name":"DyspatchApiKey","patterns":["(?i)(?:dyspatch)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9]{52})\\b"]}
-{"name":"EagleeyenetworksApiKey","patterns":["(?i)(?:eagleeyenetworks)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{15})\\b"]}
-{"name":"EasyPost","patterns":["(?i)\\bEZAK[a-z0-9]{54}","(?i)\\bEZTK[a-z0-9]{54}"]}
-{"name":"EasyinsightApiKey","patterns":["(?i)(?:easyinsight)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-zA-Z]{20})\\b"]}
-{"name":"EdamamApiKey","patterns":["(?i)(?:edamam)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"EdenaiApiKey","patterns":["(?i)(?:edenai)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{36}.[a-zA-Z0-9]{92}.[a-zA-Z0-9_]{43})\\b"]}
-{"name":"EightxeightApiKey","patterns":["(?i)(?:8x8)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{43})\\b"]}
-{"name":"ElasticApiKey","patterns":["(?i)(?:elastic)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{96})\\b"]}
-{"name":"EnablexApiKey","patterns":["(?i)(?:enablex)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{36})\\b"]}
-{"name":"EnigmaApiKey","patterns":["(?i)(?:enigma)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{40})\\b"]}
-{"name":"EthplorerApiKey","patterns":["(?i)(?:ethplorer)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z-]{22})\\b"]}
-{"name":"EtsyAccessToken","patterns":["(?i)(?:etsy)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{24})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"EtsyApiKey","patterns":["(?i)(?:etsy)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{24})\\b"]}
-{"name":"EverhourApiKey","patterns":["(?i)(?:everhour)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-f]{4}-[0-9a-f]{4}-[0-9a-f]{6}-[0-9a-f]{6}-[0-9a-f]{8})\\b"]}
-{"name":"ExchangerateApiKey","patterns":["(?i)(?:exchangerate)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{24})\\b"]}
-{"name":"ExchangeratesApiKey","patterns":["(?i)(?:exchangerates)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"ExportsdkApiKey","patterns":["(?i)(?:exportsdk)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{5,15}_[0-9a-z-]{36})\\b"]}
-{"name":"ExtractorApiKey","patterns":["(?i)(?:extractorapi)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{40})\\b"]}
-{"name":"FacebookAccessToken","patterns":["(?i)(?:facebook)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-f0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","EAACEdEose0cBA[0-9A-Za-z]+"]}
-{"name":"FacebookOauthId","patterns":["(?i)(?:facebook)(?:.|[\\n\\r]){0,40}\\b([0-9]{15,18})\\b"]}
-{"name":"FacebookOauthSecret","patterns":["(?i)(?:facebook)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9]{32})\\b"]}
-{"name":"FaceplusplusApiKey","patterns":["(?i)(?:faceplusplus)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z_-]{32})\\b"]}
-{"name":"FakejsonApiKey","patterns":["(?i)(?:fakejson)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{22})\\b"]}
-{"name":"FastforexApiKey","patterns":["(?i)(?:fastforex)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{28})\\b"]}
-{"name":"FastlyApiKey","patterns":["(?i)(?:fastly)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9=_\\-]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"FastlyApiToken","patterns":["(?i)(?:fastly)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{32})\\b"]}
-{"name":"FeedierApiKey","patterns":["(?i)(?:feedier)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{32})\\b"]}
-{"name":"FetchrssApiKey","patterns":["(?i)(?:fetchrss)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z.]{40})\\b"]}
-{"name":"FiberyApiKey","patterns":["(?i)(?:fibery)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{8}.[0-9a-f]{35})\\b"]}
-{"name":"FigmaAccessToken","patterns":["(?i)(?:figma)(?:.|[\\n\\r]){0,40}\\b([0-9]{6}-[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b"]}
-{"name":"FileioApiKey","patterns":["(?i)(?:fileio)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9.-]{39})\\b"]}
-{"name":"FinageApiKey","patterns":["\\b(API_KEY[0-9A-Z]{32})\\b"]}
-{"name":"FinancialmodelingprepApiKey","patterns":["(?i)(?:financialmodelingprep)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"FindlApiKey","patterns":["(?i)(?:findl)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{8}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{12})\\b"]}
-{"name":"Finicity","patterns":["(?i)(?:finicity)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-f0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:finicity)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{20})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"FinnhubAccessToken","patterns":["(?i)(?:finnhub)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{20})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"FinnhubApiKey","patterns":["(?i)(?:finnhub)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{20})\\b"]}
-{"name":"FixerApiKey","patterns":["(?i)(?:fixer)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9]{32})\\b"]}
-{"name":"FlatioApiKey","patterns":["(?i)(?:flat)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{128})\\b"]}
-{"name":"FleetbaseApiKey","patterns":["\\b(flb_live_[0-9a-zA-Z]{20})\\b"]}
-{"name":"FlickrAccessToken","patterns":["(?i)(?:flickr)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"FlickrApiKey","patterns":["(?i)(?:flickr)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"FlightApiKey","patterns":["(?i)(?:flightapi)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{24})\\b"]}
-{"name":"FlightStatsApiKey","patterns":["(?i)(?:flightstats)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"FloatApiKey","patterns":["(?i)(?:float)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-._+=]{59,60})\\b"]}
-{"name":"FlowdashApiKey","patterns":["(?i)(?:flowdash)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{24})\\b"]}
-{"name":"FlowdockApiKey","patterns":["(?i)(?:flowdock)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{32})\\b"]}
-{"name":"FlowfluApiKey","patterns":["(?i)(?:flowflu)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{51})\\b"]}
-{"name":"Flutterwave","patterns":["(?i)FLWPUBK_TEST-[a-h0-9]{32}-X","(?i)FLWSECK_TEST-[a-h0-9]{12}","(?i)FLWSECK_TEST-[a-h0-9]{32}-X"]}
-{"name":"FlutterwaveApiKey","patterns":["\\b(FLWSECK-[0-9a-z]{32}-X)\\b"]}
-{"name":"FmfwApiKey","patterns":["(?i)(?:fmfw)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_-]{32})\\b"]}
-{"name":"FormbucketApiKey","patterns":["(?i)(?:formbucket)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{1,}.[0-9A-Za-z]{1,}\\.[0-9A-Z-a-z\\-_]{1,})"]}
-{"name":"FormcraftApiKey","patterns":["(?i)(?:formcraft)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{16})\\b"]}
-{"name":"FormioApiKey","patterns":["(?i)(?:formio)(?:.|[\\n\\r]){0,40}\\b(eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\\.[0-9A-Za-z]{310}\\.[0-9A-Z-a-z\\-_]{43}[ \\r\\n]{1})"]}
-{"name":"FoursquareApiKey","patterns":["(?i)(?:foursquare)(?:.|[\\n\\r]){0,40}\\b([0-9A-Z]{48})\\b"]}
-{"name":"FrameIoApiToken","patterns":["(?i)fio-u-[a-z0-9\\-_=]{64}"]}
-{"name":"FrameioApiKey","patterns":["\\b(fio-u-[0-9a-zA-Z_-]{64})\\b"]}
-{"name":"FreshbooksAccessToken","patterns":["(?i)(?:freshbooks)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"FreshbooksApiKey","patterns":["(?i)(?:freshbooks)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{64})\\b"]}
-{"name":"FreshbooksApiUrl","patterns":["(?i)(?:freshbooks)(?:.|[\\n\\r]){0,40}\\b(https:\/\/www.[0-9A-Za-z_-]{1,}.com)\\b"]}
-{"name":"FreshdeskApiKey","patterns":["(?i)(?:freshdesk)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{20})\\b"]}
-{"name":"FreshworksApiKey","patterns":["(?i)(?:freshworks)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z-]{22})\\b"]}
-{"name":"FrontappApiKey","patterns":["(?i)(?:front)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{36}.[0-9a-zA-Z\\.\\-\\_]{188,244})\\b"]}
-{"name":"FulcrumApiKey","patterns":["(?i)(?:fulcrum)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{80})\\b"]}
-{"name":"FullstoryApiKey","patterns":["(?i)(?:fullstory)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9\/+]{88})\\b"]}
-{"name":"FusebillApiKey","patterns":["(?i)(?:fusebill)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{88})\\b"]}
-{"name":"FxmarketApiKey","patterns":["(?i)(?:fxmarket)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-zA-Z-_=]{20})\\b"]}
-{"name":"GCPApiKey","patterns":["(?i)\\b(AIza[0-9A-Za-z\\\\-_]{35})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"GcpApiKey","patterns":["\\{[^{]+auth_provider_x509_cert_url[^}]+\\}"]}
-{"name":"GeckoboardApiKey","patterns":["(?i)(?:geckoboard)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{44})\\b"]}
-{"name":"GenericPattern","patterns":["(?i)(?:pass|token|cred|secret|key)(?:.|[\\n\\r]){0,40}(\\b[\\x21-\\x7e]{16,64}\\b)"]}
-{"name":"GengoApiKey","patterns":["(?i)(?:gengo)(?:.|[\\n\\r]){0,40}([ ]{0,1}[0-9a-zA-Z\\[\\]\\-\\(\\)\\{\\}|_^@$=~]{64}[ \\r\\n]{1})"]}
-{"name":"GeoapifyApiKey","patterns":["(?i)(?:geoapify)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"GeocodeApiKey","patterns":["(?i)(?:geocode)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{28})\\b"]}
-{"name":"GeocodeioApiKey","patterns":["(?i)(?:geocod)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{39})\\b"]}
-{"name":"GeocodifyApiKey","patterns":["(?i)(?:geocodify)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{40})\\b"]}
-{"name":"GeoipifiApiKey","patterns":["(?i)(?:ipifi)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z_]{32})\\b"]}
-{"name":"GetemailApiKey","patterns":["(?i)(?:getemail)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-]{20})\\b"]}
-{"name":"GetemailsApiKey","patterns":["(?i)(?:getemails)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{26})\\b"]}
-{"name":"GetgeoaApiKey","patterns":["(?i)(?:getgeoapi)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{40})\\b"]}
-{"name":"GetgistApiKey","patterns":["(?i)(?:getgist)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z+=]{68})"]}
-{"name":"GetsandboxApiKey","patterns":["(?i)(?:getsandbox)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{40})\\b"]}
-{"name":"GitHubTokenCustom","patterns":["(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36}","gho_[0-9a-zA-Z]{36}","github_pat_[0-9a-zA-Z_]{82}"]}
-{"name":"GitLab","patterns":["GR1348941[0-9a-zA-Z\\-\\_]{20}","glpat-[0-9a-zA-Z\\-\\_]{20}","glptt-[0-9a-f]{40}"]}
-{"name":"GithubPrivateKey","patterns":["(?i)(?:github)(?:.|[\\n\\r]){0,40}(-----BEGIN RSA PRIVATE KEY-----\\s[A-Za-z0-9+\\\/\\s]*\\s-----END RSA PRIVATE KEY-----)"]}
-{"name":"GithubToken","patterns":["\\b((?:ghp|gho|ghu|ghs|ghr)_[a-zA-Z0-9]{36,255})\\b"]}
-{"name":"GitlabApiKey","patterns":["(?i)(?:gitlab)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9\\-=_]{20,22})\\b"]}
-{"name":"GitlabApiKeyV2","patterns":["\\b(glpat-[a-zA-Z0-9\\-=_]{20,22})\\b"]}
-{"name":"GitterAccessToken","patterns":["(?i)(?:gitter)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9_-]{40})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"GitterApiKey","patterns":["(?i)(?:gitter)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{40})\\b"]}
-{"name":"GlassnodeApiKey","patterns":["(?i)(?:glassnode)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{27})\\b"]}
-{"name":"GlitterlyApiKey","patterns":["(?i)(?:glitterlyapi)(?:.|[\\n\\r]){0,40}\\b([0-9a-z-]{36})\\b"]}
-{"name":"GoCardlessApiToken","patterns":["(?:gocardless)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(live_[a-z0-9\\-_=]{40})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"GocanvasApiKey","patterns":["(?i)(?:gocanvas)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z\/+]{43}=[ \\r\\n]{1})"]}
-{"name":"GocardlessApiKey","patterns":["\\b(live_[0-9A-Za-z\\_\\-]{40}[ \"'\\r\\n]{1})"]}
-{"name":"GooddayApiKey","patterns":["(?i)(?:goodday)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"Grafana","patterns":["(?i)\\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,2})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)\\b(glc_[A-Za-z0-9+\/]{32,400}={0,2})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)\\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"GraphcmsApiKey","patterns":["\\b(ey[a-zA-Z0-9]{73}.ey[a-zA-Z0-9]{365}.[a-zA-Z0-9_-]{683})\\b"]}
-{"name":"GraphhopperApiKey","patterns":["(?i)(?:graphhopper)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"GrooveApiKey","patterns":["(?i)(?:groove)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{64})"]}
-{"name":"GuardianApiKey","patterns":["\\b([0-9Aa-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b"]}
-{"name":"GumroadApiKey","patterns":["(?i)(?:gumroad)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z-]{43})\\b"]}
-{"name":"GuruApiKey","patterns":["(?i)(?:guru)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\\b"]}
-{"name":"GyazoApiKey","patterns":["(?i)(?:gyazo)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z-]{43})\\b"]}
-{"name":"HappiApiKey","patterns":["(?i)(?:happi)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{56})"]}
-{"name":"HappyscribeApiKey","patterns":["(?i)(?:happyscribe)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{24})\\b"]}
-{"name":"HarvestApiKey","patterns":["(?i)(?:harvest)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z._]{97})\\b"]}
-{"name":"HashiCorpTFApiToken","patterns":["(?i)[a-z0-9]{14}\\.atlasv1\\.[a-z0-9\\-_=]{60,70}"]}
-{"name":"HellosignApiKey","patterns":["(?i)(?:hellosign)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9\/+]{64})\\b"]}
-{"name":"HelpcrunchApiKey","patterns":["(?i)(?:helpcrunch)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9+\/=]{328})"]}
-{"name":"HelpscoutApiKey","patterns":["(?i)(?:helpscout)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9]{56})\\b"]}
-{"name":"HereapiKey","patterns":["(?i)(?:hereapi)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9\\S]{43})\\b"]}
-{"name":"HerokuApiKey","patterns":["(?i)(?:heroku)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b","(?i)(?:heroku)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"HiveApiKey","patterns":["(?i)(?:hive)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"HiveageApiKey","patterns":["(?i)(?:hiveage)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z\\_\\-]{20})\\b"]}
-{"name":"HolidayapiKey","patterns":["(?i)(?:holidayapi)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"HostApiKey","patterns":["(?i)(?:host)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{14})\\b"]}
-{"name":"Html2PdfApiKey","patterns":["(?i)(?:html2pdf)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{64})\\b"]}
-{"name":"HubSpotApiToken","patterns":["(?i)(?:hubspot)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"HubspotApiKey","patterns":["(?i)(?:hubspot)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9]{8}\\-[A-Za-z0-9]{4}\\-[A-Za-z0-9]{4}\\-[A-Za-z0-9]{4}\\-[A-Za-z0-9]{12})\\b"]}
-{"name":"HuggingFace","patterns":["(?:^|[\\\\'\"` >=:\\(,)])(api_org_[a-zA-Z]{34})(?:$|[\\\\'\"` <\\),])","(?:^|[\\\\'\"` >=:])(hf_[a-zA-Z]{34})(?:$|[\\\\'\"` <])"]}
-{"name":"HumanityApiKey","patterns":["(?i)(?:humanity)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{40})\\b"]}
-{"name":"HunterApiKey","patterns":["(?i)(?:hunter)(?:.|[\\n\\r]){0,40}\\b([a-z0-9_-]{40})\\b"]}
-{"name":"HybiscusApiKey","patterns":["(?i)(?:hybiscus)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{43})\\b"]}
-{"name":"HypertrackApiKey","patterns":["(?i)(?:hypertrack)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z\\_\\-]{54})\\b"]}
-{"name":"IbmApiKey","patterns":["(?i)(?:ibm)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{44})\\b"]}
-{"name":"IbmCloudIam","patterns":["(?:(?<=\\W)|(?<=^))(?:\\[|)(?:\"|\\'|)(?:ibm(?:_|-|)cloud(?:_|-|)iam|cloud(?:_|-|)iam|ibm(?:_|-|)cloud|ibm(?:_|-|)iam|ibm|iam|cloud|)(?:_|-|)(?:api|)(?:_|-|)(?:key|pwd|password|pass|token)(?:\"|\\'|)(?:\\]|)(?: *)(?:=|:|:=|=>| +|::)(?: *)(?:\"|\\'|)([a-zA-Z0-9_\\-]{44}(?![a-zA-Z0-9_\\-]))(?:\"|\\'|)"]}
-{"name":"IbmCosHmac","patterns":["(?:(?<=\\W)|(?<=^))(?:\\[|)(?:\"|\\'|)(?:(?:ibm)?[-_]?cos[-_]?(?:hmac)?|)(?:_|-|)(?:secret[-_]?(?:access)?[-_]?key)(?:\"|\\'|)(?:\\]|)(?: *)(?:=|:|:=|=>| +|::)(?: *)(?:\"|\\'|)([a-f0-9]{48}(?![a-f0-9]))(?:\"|\\'|)"]}
-{"name":"IconfinderApiKey","patterns":["(?i)(?:iconfinder)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{64})\\b"]}
-{"name":"IexapisApiKey","patterns":["(?i)(?:iexapis)(?:.|[\\n\\r]){0,40}\\b(sk_[a-z0-9]{32})\\b"]}
-{"name":"IexcloudApiKey","patterns":["(?i)(?:iexcloud)(?:.|[\\n\\r]){0,40}\\b([a-z0-9_]{35})\\b"]}
-{"name":"Image4ApiKey","patterns":["(?i)(?:image4)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{22}[0-9a-zA-Z\\=]{2})"]}
-{"name":"ImagekitApiKey","patterns":["(?i)(?:imagekit)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_=]{36})"]}
-{"name":"ImaggaApiKey","patterns":["(?i)(?:imagga)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z=]{72})"]}
-{"name":"ImpalaApiKey","patterns":["(?i)(?:impala)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z_]{46})\\b"]}
-{"name":"InsightlyApiKey","patterns":["(?i)(?:insightly)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"InstabotApiKey","patterns":["(?i)(?:instabot)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z=+\\\/]{43}[0-9a-zA-Z+\\\/=]{1})"]}
-{"name":"IntegromatApiKey","patterns":["(?i)(?:integromat)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"IntercomApiKey","patterns":["(?i)(?:intercom)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9\\W\\S]{59}\\=)"]}
-{"name":"IntercomApiToken","patterns":["(?i)(?:intercom)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9=_\\-]{60})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"IntersellerApiKey","patterns":["(?i)(?:interseller)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b"]}
-{"name":"IntrinioApiKey","patterns":["(?i)(?:intrinio)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{44})\\b"]}
-{"name":"InvoiceoceanApiKey","patterns":["(?i)(?:invoiceocean)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{20})\\b"]}
-{"name":"IpapiKey","patterns":["(?i)(?:ipapi)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"IpgeolocationApiKey","patterns":["(?i)(?:ipgeolocation)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"IpifyApiKey","patterns":["(?i)(?:ipify)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_-]{32})\\b"]}
-{"name":"IpinfodbApiKey","patterns":["(?i)(?:ipinfodb)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{64})\\b"]}
-{"name":"IpqualityApiKey","patterns":["(?i)(?:ipquality)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"IpstackApiKey","patterns":["(?i)(?:ipstack)(?:.|[\\n\\r]){0,40}\\b([a-fA-f0-9]{32})\\b"]}
-{"name":"JFrog","patterns":["(?i)(?:jfrog|artifactory|bintray|xray)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:jfrog|artifactory|bintray|xray)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{73})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"JWTBase64","patterns":["\\bZXlK(?:(?P<alg>aGJHY2lPaU)|(?P<apu>aGNIVWlPaU)|(?P<apv>aGNIWWlPaU)|(?P<aud>aGRXUWlPaU)|(?P<b64>aU5qUWlP)|(?P<crit>amNtbDBJanBi)|(?P<cty>amRIa2lPaU)|(?P<epk>bGNHc2lPbn)|(?P<enc>bGJtTWlPaU)|(?P<jku>cWEzVWlPaU)|(?P<jwk>cWQyc2lPb)|(?P<iss>cGMzTWlPaU)|(?P<iv>cGRpSTZJ)|(?P<kid>cmFXUWlP)|(?P<key_ops>clpYbGZiM0J6SWpwY)|(?P<kty>cmRIa2lPaUp)|(?P<nonce>dWIyNWpaU0k2)|(?P<p2c>d01tTWlP)|(?P<p2s>d01uTWlPaU)|(?P<ppt>d2NIUWlPaU)|(?P<sub>emRXSWlPaU)|(?P<svt>emRuUWlP)|(?P<tag>MFlXY2lPaU)|(?P<typ>MGVYQWlPaUp)|(?P<url>MWNtd2l)|(?P<use>MWMyVWlPaUp)|(?P<ver>MlpYSWlPaU)|(?P<version>MlpYSnphVzl1SWpv)|(?P<x>NElqb2)|(?P<x5c>NE5XTWlP)|(?P<x5t>NE5YUWlPaU)|(?P<x5ts256>NE5YUWpVekkxTmlJNkl)|(?P<x5u>NE5YVWlPaU)|(?P<zip>NmFYQWlPaU))[a-zA-Z0-9\\\/\\\\_+\\-\\r\\n]{40,}={0,2}"]}
-{"name":"JdbcToken","patterns":["(?i)jdbc:[\\w]{3,10}:\\\/\\\/\\w[\\s\\S]{0,512}?password[=: \\\"']+(?P<pass>[^<{($]*?)[ \\s'\\\"]+"]}
-{"name":"JiraDomainUrl","patterns":["(?i)(?:jira)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{5,24}\\.[a-zA-Z-0-9]{3,16}\\.[a-zA-Z-0-9]{3,16})\\b"]}
-{"name":"JiraToken","patterns":["(?i)(?:jira)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{24})\\b"]}
-{"name":"JotfromApiKey","patterns":["(?i)(?:jotform)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-z]{32})\\b"]}
-{"name":"JumpcloudApiKey","patterns":["(?i)(?:jumpcloud)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{40})\\b"]}
-{"name":"JuroApiKey","patterns":["(?i)(?:juro)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{40})\\b"]}
-{"name":"JwtToken","patterns":["eyJ[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+\/=]*?"]}
-{"name":"KanbanApiKey","patterns":["(?i)(?:kanban)(?:.|[\\n\\r]){0,40}\\b([0-9A-Z]{12})\\b"]}
-{"name":"KarmaacrmApiKey","patterns":["(?i)(?:karma)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{20})\\b"]}
-{"name":"KeenioApiKey","patterns":["(?i)(?:keen)(?:.|[\\n\\r]){0,40}\\b([0-9A-Z]{64})\\b"]}
-{"name":"KickboxApiKey","patterns":["(?i)(?:kickbox)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]+[a-zA-Z0-9]{64})\\b"]}
-{"name":"KlipfolioApiKey","patterns":["(?i)(?:klipfolio)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{40})\\b"]}
-{"name":"KnapsackproApiKey","patterns":["(?i)(?:knapsackpro)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"KontentApiKey","patterns":["(?i)(?:kontent)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"KrakenAccessToken","patterns":["(?i)(?:kraken)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9\\\/=_\\+\\-]{80,90})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"KrakenApiKey","patterns":["(?i)(?:kraken)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z\\\/\\+=]{56}[ \"'\\r\\n]{1})"]}
-{"name":"KrakenApiPrivateKey","patterns":["(?i)(?:kraken)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z\\\/\\+=]{86,88}[ \"'\\r\\n]{1})"]}
-{"name":"Kucoin","patterns":["(?i)(?:kucoin)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:kucoin)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-f0-9]{24})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"KucoinApiKey","patterns":["(?i)(?:kucoin)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{24})\\b"]}
-{"name":"KylasApiKey","patterns":["(?i)(?:kylas)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"LanguagelayerApiKey","patterns":["(?i)(?:languagelayer)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"LastfmApiKey","patterns":["(?i)(?:lastfm)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"LaunchdarklyAccessToken","patterns":["(?i)(?:launchdarkly)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9=_\\-]{40})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"LaunchdarklyApiKey","patterns":["(?i)(?:launchdarkly)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{40})\\b"]}
-{"name":"LeadfeederApiKey","patterns":["(?i)(?:leadfeeder)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-]{43})\\b"]}
-{"name":"LendflowApiKey","patterns":["(?i)(?:lendflow)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{36}\\.[a-zA-Z0-9]{235}\\.[a-zA-Z0-9]{32}\\-[a-zA-Z0-9]{47}\\-[a-zA-Z0-9_]{162}\\-[a-zA-Z0-9]{42}\\-[a-zA-Z0-9_]{40}\\-[a-zA-Z0-9_]{66}\\-[a-zA-Z0-9_]{59}\\-[a-zA-Z0-9]{7}\\-[a-zA-Z0-9_]{220})\\b"]}
-{"name":"LessannoyingcrmApiKey","patterns":["(?i)(?:less)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-]{57})\\b"]}
-{"name":"LexigramApiKey","patterns":["(?i)(?:lexigram)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9\\S]{301})\\b"]}
-{"name":"Linear","patterns":["(?i)(?:linear)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-f0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)lin_api_[a-z0-9]{40}"]}
-{"name":"LinearapiKey","patterns":["\\b(lin_api_[0-9A-Za-z]{40})\\b"]}
-{"name":"LinemessagingApiKey","patterns":["(?i)(?:line)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9+\/]{171,172})\\b"]}
-{"name":"LinenotifyApiKey","patterns":["(?i)(?:linenotify)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{43})\\b"]}
-{"name":"LinkedIn","patterns":["(?i)(?:linkedin|linked-in)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{14})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:linkedin|linked-in)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{16})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"LinkpreviewApiKey","patterns":["(?i)(?:linkpreview)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"LiveagentApiKey","patterns":["(?i)(?:liveagent)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"LivestormApiKey","patterns":["(?i)(?:livestorm)(?:.|[\\n\\r]){0,40}\\b(eyJhbGciOiJIUzI1NiJ9\\.eyJhdWQiOiJhcGkubGl2ZXN0b3JtLmNvIiwianRpIjoi[0-9A-Z-a-z]{134}\\.[0-9A-Za-z\\-\\_]{43}[ \\r\\n]{1})"]}
-{"name":"LoadmillApiKey","patterns":["(?i)(?:loadmill)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{40})\\b"]}
-{"name":"Lob","patterns":["(?i)(?:lob)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}((live|test)_[a-f0-9]{35})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:lob)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}((test|live)_pub_[a-f0-9]{31})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"LobApiKey","patterns":["(?i)(?:lob)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]{40})\\b"]}
-{"name":"LocationiqApiKey","patterns":["\\b(pk\\.[a-zA-Z-0-9]{32})\\b"]}
-{"name":"LoginradiusApiKey","patterns":["(?i)(?:loginradius)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b"]}
-{"name":"LokaliseApiKey","patterns":["(?i)(?:lokalise)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{40})\\b"]}
-{"name":"LoyverseApiKey","patterns":["(?i)(?:loyverse)(?:.|[\\n\\r]){0,40}\\b([0-9-a-z]{32})\\b"]}
-{"name":"LunchmoneyApiKey","patterns":["(?i)(?:lunchmoney)(?:.|[\\n\\r]){0,40}\\b([a-f0-9]{50})\\b`"]}
-{"name":"LunoApiKey","patterns":["(?i)(?:luno)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_-]{43})\\b"]}
-{"name":"M3OApiKey","patterns":["(?i)(?:m3o)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{48})\\b"]}
-{"name":"MacaddressApiKey","patterns":["(?i)(?:macaddress)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]{32})\\b"]}
-{"name":"MadkuduApiKey","patterns":["(?i)(?:madkudu)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{32})\\b"]}
-{"name":"MagicbellApiKey","patterns":["(?i)(?:magicbell)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{40})\\b"]}
-{"name":"MagneticApiKey","patterns":["(?i)(?:magnetic)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b"]}
-{"name":"MailboxlayerApiKey","patterns":["(?i)(?:mailboxlayer)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"Mailchimp","patterns":["[0-9a-z]{32}-us[0-9]{1,2}"]}
-{"name":"MailchimpApiKey","patterns":["[0-9a-f]{32}-us[0-9]{1,2}"]}
-{"name":"MailerliteApiKey","patterns":["(?i)(?:mailerlite)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"Mailgun","patterns":["(?i)(?:mailgun)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:mailgun)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(key-[a-f0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:mailgun)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(pubkey-[a-f0-9]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"MailgunApiKey","patterns":["(?i)(?:mailgun)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{72})\\b"]}
-{"name":"MailjetApiKey","patterns":["(?i)(?:mailjet)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9]{32})\\b"]}
-{"name":"MailjetApiSecret","patterns":["(?i)(?:mailjet)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9]{87}\\=)"]}
-{"name":"MailmodoApiKey","patterns":["(?i)(?:mailmodo)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9]{7}-[A-Z0-9]{7}-[A-Z0-9]{7}-[A-Z0-9]{7})\\b"]}
-{"name":"MailsacApiKey","patterns":["(?i)(?:mailsac)(?:.|[\\n\\r]){0,40}\\b(k_[0-9A-Za-z]{36,})\\b"]}
-{"name":"MandrillApiKey","patterns":["(?i)(?:mandrill)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{22})\\b"]}
-{"name":"ManifestApiKey","patterns":["(?i)(?:manifest)(?:.|[\\n\\r]){0,40}\\b([a-zA-z0-9]{32})\\b"]}
-{"name":"MapBoxApiToken","patterns":["(?i)(?:mapbox)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(pk\\.[a-z0-9]{60}\\.[a-z0-9]{22})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"MapboxApiKey","patterns":["\\b(sk\\.[a-zA-Z-0-9\\.]{80,240})\\b"]}
-{"name":"MapquestApiKey","patterns":["(?i)(?:mapquest)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{32})\\b"]}
-{"name":"MarketstackApiKey","patterns":["(?i)(?:marketstack)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"MattermostAccessToken","patterns":["(?i)(?:mattermost)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{26})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"MattermostApiKey","patterns":["(?i)(?:mattermost)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{26})\\b"]}
-{"name":"MavenlinkApiKey","patterns":["(?i)(?:mavenlink)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{64})\\b"]}
-{"name":"MaxmindApiKey","patterns":["(?i)(?:maxmind|geoip)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{16})\\b"]}
-{"name":"MeaningcloudApiKey","patterns":["(?i)(?:meaningcloud)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"MediastackApiKey","patterns":["(?i)(?:mediastack)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"MeistertaskApiKey","patterns":["(?i)(?:meistertask)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{43})\\b"]}
-{"name":"MesiboApiKey","patterns":["(?i)(?:mesibo)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{64})\\b"]}
-{"name":"MessageBird","patterns":["(?i)(?:messagebird|message-bird|message_bird)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:messagebird|message-bird|message_bird)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{25})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"MessagebirdApiKey","patterns":["(?i)(?:messagebird)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{25})\\b"]}
-{"name":"MetaapiKey","patterns":["(?i)(?:metaapi|meta-api)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{64})\\b"]}
-{"name":"MetriloApiKey","patterns":["(?i)(?:metrilo)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{16})\\b"]}
-{"name":"MicrosoftTeamsWebhook","patterns":["https:\\\/\\\/[a-z0-9]+\\.webhook\\.office\\.com\\\/webhookb2\\\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}@[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}\\\/IncomingWebhook\\\/[a-z0-9]{32}\\\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}"]}
-{"name":"MidiseApiKey","patterns":["midi-662b69edd2[a-zA-Z0-9]{54}"]}
-{"name":"MindmeisterApiKey","patterns":["(?i)(?:mindmeister)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{43})\\b"]}
-{"name":"MiroApiKey","patterns":["(?i)(?:miro)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{27})\\b"]}
-{"name":"MiteApiKey","patterns":["(?i)(?:mite)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{16})\\b"]}
-{"name":"MixmaxApiKey","patterns":["(?i)(?:mixmax)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_-]{36})\\b"]}
-{"name":"MixpanelApiKey","patterns":["(?i)(?:mixpanel)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-]{32})\\b"]}
-{"name":"MockarooApiKey","patterns":["(?i)(?:mockaroo)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{8})\\b"]}
-{"name":"ModerationApiKey","patterns":["(?i)(?:moderation)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{36}\\.[a-zA-Z0-9]{115}\\.[a-zA-Z0-9_]{43})\\b"]}
-{"name":"MondayApiKey","patterns":["(?i)(?:monday)(?:.|[\\n\\r]){0,40}\\b(ey[a-zA-Z0-9_.]{210,225})\\b"]}
-{"name":"MoonclerkApiKey","patterns":["(?i)(?:moonclerk)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"MoosendApiKey","patterns":["(?i)(?:moosend)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b"]}
-{"name":"MrticktockPassword","patterns":["(?i)(?:mrticktock)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9!=@#$%()_^]{1,50})"]}
-{"name":"MsteamsWebhook","patterns":["(https:\\\/\\\/[a-zA-Z-0-9]+\\.webhook\\.office\\.com\\\/webhookb2\\\/[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12}\\@[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12}\\\/IncomingWebhook\\\/[a-zA-Z-0-9]{32}\\\/[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12})"]}
-{"name":"MuxApiKey","patterns":["(?i)(?:mux)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b"]}
-{"name":"MuxSecretToken","patterns":["(?i)(?:mux)(?:.|[\\n\\r]){0,40}([ \\r\\n]{0,1}[0-9A-Za-z\\\/\\+]{75}[ \\r\\n]{1})"]}
-{"name":"MyintervalsApiKey","patterns":["(?i)(?:myintervals)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{11})\\b"]}
-{"name":"NYTimesAccessToken","patterns":["(?i)(?:nytimes|new-york-times,|newyorktimes)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9=_\\-]{32})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"NasdaqdatalinkApiKey","patterns":["(?i)(?:nasdaq)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_-]{20})\\b"]}
-{"name":"NethuntApiKey","patterns":["(?i)(?:nethunt)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-\\S]{36})\\b"]}
-{"name":"NetlifyAccessToken","patterns":["(?i)(?:netlify)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9=_\\-]{40,46})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"NetlifyApiKey","patterns":["(?i)(?:netlify)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{43,45})\\b"]}
-{"name":"NeutrinoApiKey","patterns":["(?i)(?:neutrinoapi)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{48})\\b"]}
-{"name":"NewRelic","patterns":["(?i)(?:new-relic|newrelic|new_relic)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(NRAK-[a-z0-9]{27})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:new-relic|newrelic|new_relic)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(NRJS-[a-f0-9]{19})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:new-relic|newrelic|new_relic)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"NewrelicApiKey","patterns":["(?i)(?:newrelic)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_\\.]{4}-[A-Za-z0-9_\\.]{42})\\b"]}
-{"name":"NewsapiKey","patterns":["(?i)(?:newsapi)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})"]}
-{"name":"NewscatcherApiKey","patterns":["(?i)(?:newscatcher)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z_]{43})\\b"]}
-{"name":"NexmoApiKey","patterns":["(?i)(?:nexmo)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{8})\\b"]}
-{"name":"NexmoApiSecret","patterns":["(?i)(?:nexmo)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{16})\\b"]}
-{"name":"NftportApiKey","patterns":["(?i)(?:nftport)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\\b"]}
-{"name":"NicereplyApiKey","patterns":["(?i)(?:nicereply)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{40})\\b"]}
-{"name":"NightfallApiKey","patterns":["\\b(NF\\-[a-zA-Z0-9]{32})\\b"]}
-{"name":"NimbleApiKey","patterns":["(?i)(?:nimble)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{30})\\b"]}
-{"name":"NitroApiKey","patterns":["(?i)(?:nitro)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{32})\\b"]}
-{"name":"NoticeableApiKey","patterns":["(?i)(?:noticeable)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{20})\\b"]}
-{"name":"NotionApiKey","patterns":["\\b(secret_[A-Za-z0-9]{43})\\b"]}
-{"name":"NozbeteamsApiKey","patterns":["(?i)(?:nozbe|nozbeteams)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{16}_[0-9A-Za-z\\-_]{64}[ \\r\\n]{1})"]}
-{"name":"Npm","patterns":["\\\/\\\/.+\\\/:_authToken=\\s*((npm_.+)|([A-Fa-f0-9-]{36})).*"]}
-{"name":"NumverifyApiKey","patterns":["(?i)(?:numverify)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"NutritionixApiKey","patterns":["(?i)(?:nutritionix)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"NylasApiKey","patterns":["(?i)(?:nylas)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{30})\\b"]}
-{"name":"NytimesApiKey","patterns":["(?i)(?:nytimes)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z-]{32})\\b"]}
-{"name":"OandaApiKey","patterns":["(?i)(?:oanda)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{24})\\b"]}
-{"name":"OktaAccessToken","patterns":["(?i)(?:okta)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9=_\\-]{42})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"OktaApiDomainUrl","patterns":["\\[a-z0-9-]{1,40}\\.okta(?:preview|-emea){0,1}\\.com"]}
-{"name":"OktaApiToken","patterns":["00[a-zA-Z0-9_-]{40}"]}
-{"name":"OmnisendApiKey","patterns":["(?i)(?:omnisend)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z-]{75})\\b"]}
-{"name":"OnedeskPassword","patterns":["(?i)(?:onedesk)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9!=@#$%^]{8,64})"]}
-{"name":"OneloginOauthClientSecret","patterns":["(?i)secret[a-zA-Z0-9_' \"=]{0,20}([a-z0-9]{64})"]}
-{"name":"OnepagecrmApiKey","patterns":["(?i)(?:onepagecrm)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9=]{44})"]}
-{"name":"OnesignalApiKeyUuid","patterns":["(?i)(?:onesignal)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b"]}
-{"name":"OnwaterApiKey","patterns":["(?i)(?:onwater)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_-]{20})\\b"]}
-{"name":"OopspamApiKey","patterns":["(?i)(?:oopspam)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{40})\\b"]}
-{"name":"OpenAIApiKey","patterns":["(?i)\\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"OpencagedataApiKey","patterns":["(?i)(?:opencagedata)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"OpengraphrApiKey","patterns":["(?i)(?:opengraphr)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-zA-Z]{80})\\b"]}
-{"name":"OpenuvApiKey","patterns":["(?i)(?:openuv)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"OpenweatherApiKey","patterns":["(?i)(?:openweather)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"OptimizelyApiKey","patterns":["(?i)(?:optimizely)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z-:]{54})\\b"]}
-{"name":"OwlbotApiKey","patterns":["(?i)(?:owlbot)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{40})\\b"]}
-{"name":"PackagecloudApiKey","patterns":["(?i)(?:packagecloud)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{48})\\b"]}
-{"name":"PagerdutyApiKey","patterns":["(?i)(?:pagerduty)(?:.|[\\n\\r]){0,40}\\b([a-z]{1}\\+[a-zA-Z]{9}\\-[a-z]{2}\\-[a-z0-9]{5})\\b"]}
-{"name":"PandadocApiKey","patterns":["(?i)(?:pandadoc)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{40})\\b"]}
-{"name":"PandascoreApiKey","patterns":["(?i)(?:pandascore)(?:.|[\\n\\r]){0,40}([ \\r\\n]{0,1}[0-9A-Za-z\\-\\_]{51}[ \\r\\n]{1})"]}
-{"name":"PaperformApiKey","patterns":["(?i)(?:paperform)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z-._]{850,1000})\\b"]}
-{"name":"ParalleldotsApiKey","patterns":["(?i)(?:paralleldots)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{43})\\b"]}
-{"name":"ParsehubApiKey","patterns":["(?i)(?:parsehub)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{12})\\b"]}
-{"name":"ParsersApiKey","patterns":["(?i)(?:parsers)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{64})\\b"]}
-{"name":"PartnerstackApiKey","patterns":["(?i)(?:partnerstack)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{64})\\b"]}
-{"name":"PassbaseApiKey","patterns":["(?i)(?:passbase)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{128})\\b"]}
-{"name":"PastebinApiKey","patterns":["(?i)(?:pastebin)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]{32})\\b"]}
-{"name":"PaydirtappApiKey","patterns":["(?i)(?:paydirtapp)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"PaymoappApiKey","patterns":["(?i)(?:paymoapp)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{44})\\b"]}
-{"name":"PaymongoApiKey","patterns":["(?i)(?:paymongo)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]{32})\\b"]}
-{"name":"Paypal\/BraintreeAccessToken","patterns":["access_token\\$production\\$[0-9a-z]{16}\\$[0-9a-f]{32}"]}
-{"name":"PaypalApiKey","patterns":["\\b([A-Za-z0-9_\\.]{69}-[A-Za-z0-9_\\.]{10})\\b"]}
-{"name":"PaystackApiKey","patterns":["\\b(sk\\_[a-z]{1,}\\_[A-Za-z0-9]{40})\\b"]}
-{"name":"PdflayerApiKey","patterns":["(?i)(?:pdflayer)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"PdfshiftApiKey","patterns":["(?i)(?:pdfshift)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{32})\\b"]}
-{"name":"PeopledatalabsApiKey","patterns":["(?i)(?:peopledatalabs)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{64})\\b"]}
-{"name":"PepipostApiKey","patterns":["(?i)(?:pepipost|netcore)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{32})\\b"]}
-{"name":"PicaticApiKey","patterns":["sk_live_[0-9a-z]{32}"]}
-{"name":"PinataApiKey","patterns":["(?i)(?:pinata)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{64})\\b"]}
-{"name":"PipedreamApiKey","patterns":["(?i)(?:pipedream)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"PipedriveApiKey","patterns":["(?i)(?:pipedrive)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{40})\\b"]}
-{"name":"PivotaltrackerApiKey","patterns":["(?i)(?:pivotal)(?:.|[\\n\\r]){0,40}([a-z0-9]{32})"]}
-{"name":"PixabayApiKey","patterns":["(?i)(?:pixabay)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{34})\\b"]}
-{"name":"PlaidApiKey","patterns":["(?i)(?:plaid)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{30})\\b"]}
-{"name":"PlanetScale","patterns":["(?i)\\b(pscale_oauth_[a-z0-9=\\-_\\.]{32,64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)\\b(pscale_pw_[a-z0-9=\\-_\\.]{32,64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)\\b(pscale_tkn_[a-z0-9=\\-_\\.]{32,64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"PlanviewleankitApiKey","patterns":["(?i)(?:planviewleankit|planview)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{128})\\b"]}
-{"name":"PlanviewleankitApiSubdomain","patterns":["(?i)(?:planviewleankit|planview)(?:.|[\\n\\r]){0,40}(?:subdomain).\\b([a-zA-Z][a-zA-Z0-9.-]{1,23}[a-zA-Z0-9])\\b"]}
-{"name":"PlanyoApiKey","patterns":["(?i)(?:planyo)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{62})\\b"]}
-{"name":"PlivoApiKey","patterns":["(?i)(?:plivo)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{40})\\b"]}
-{"name":"PodioApiKey","patterns":["(?i)(?:podio)(?:.|[\\n\\r]){0,40}\\b([[0-9a-z]{32})\\b"]}
-{"name":"PollsapiKey","patterns":["(?i)(?:pollsapi)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9]{28})\\b"]}
-{"name":"PoloniexApiKey","patterns":["(?i)(?:poloniex)(?:.|[\\n\\r]){0,40}\\b([0-9A-Z]{8}-[0-9A-Z]{8}-[0-9A-Z]{8}-[0-9A-Z]{8})\\b"]}
-{"name":"PolygonApiKey","patterns":["(?i)(?:polygon)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{32})\\b"]}
-{"name":"PositionstackApiKey","patterns":["(?i)(?:positionstack)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]{32})\\b"]}
-{"name":"PostageappApiKey","patterns":["(?i)(?:postageapp)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{32})\\b"]}
-{"name":"PostbacksApiKey","patterns":["(?i)(?:postbacks)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b"]}
-{"name":"PosthogApiKey","patterns":["\\b(phc_[a-zA-Z0-9_]{43})\\b"]}
-{"name":"PostmanApiKey","patterns":["\\b(PMAK-[a-zA-Z-0-9]{59})\\b"]}
-{"name":"PostmanApiToken","patterns":["(?i)\\b(PMAK-[a-f0-9]{24}-[a-f0-9]{34})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"PostmarkApiKey","patterns":["(?i)(?:postmark)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b"]}
-{"name":"PowrbotApiKey","patterns":["(?i)(?:powrbot)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{40})\\b"]}
-{"name":"PrefectApiToken","patterns":["(?i)\\b(pnu_[a-z0-9]{36})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"PrivateKey","patterns":["\/(?i)-----\\s*?BEGIN[ A-Z0-9_-]*?PRIVATE KEY\\s*?-----[\\s\\S]*?----\\s*?END[ A-Z0-9_-]*? PRIVATE KEY\\s*?-----\/gm","BEGIN DSA PRIVATE KEY","BEGIN EC PRIVATE KEY","BEGIN OPENSSH PRIVATE KEY","BEGIN PGP PRIVATE KEY BLOCK","BEGIN PRIVATE KEY","BEGIN RSA PRIVATE KEY","BEGIN SSH2 ENCRYPTED PRIVATE KEY","PuTTY-User-Key-File-2"]}
-{"name":"ProspectcrmApiKey","patterns":["(?i)(?:prospect)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{32})\\b"]}
-{"name":"ProspectioApiKey","patterns":["(?i)(?:prospect)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z-]{50})\\b"]}
-{"name":"ProtocolsioApiKey","patterns":["(?i)(?:protocols)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{64})\\b"]}
-{"name":"ProxycrawlApiKey","patterns":["(?i)(?:proxycrawl)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]{22})\\b"]}
-{"name":"PubnubSubscriptionKey","patterns":["\\b(sub-c-[0-9a-z]{8}-[a-z]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\\b"]}
-{"name":"PubnubpublishKey","patterns":["\\b(pub-c-[0-9a-z]{8}-[0-9a-z]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\\b"]}
-{"name":"PulumiApiToken","patterns":["(?i)\\b(pul-[a-f0-9]{40})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"PurestakeApiKey","patterns":["(?i)(?:purestake)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{40})\\b"]}
-{"name":"PushbulletApiKey","patterns":["(?i)(?:pushbullet)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_\\.]{34})\\b"]}
-{"name":"PusherApiSecret","patterns":["(?i)(?:pusher)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{20})\\b"]}
-{"name":"PyPiUploadToken","patterns":["pypi-AgEIcHlwaS5vcmc[A-Za-z0-9\\-_]{50,1000}"]}
-{"name":"QaseApiKey","patterns":["(?i)(?:qase)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{40})\\b"]}
-{"name":"QualarooApiKey","patterns":["(?i)(?:qualaroo)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z=]{64})"]}
-{"name":"QuboleApiKey","patterns":["(?i)(?:qubole)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{64})\\b"]}
-{"name":"QuickmetricsApiKey","patterns":["(?i)(?:quickmetrics)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_-]{22})\\b"]}
-{"name":"RapidApiAccessToken","patterns":["(?i)(?:rapidapi)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9_-]{50})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"RapidapiKey","patterns":["(?i)(?:rapidapi)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{50})\\b"]}
-{"name":"RavenApiKey","patterns":["(?i)(?:raven)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9-]{16})\\b"]}
-{"name":"RawgApiKey","patterns":["(?i)(?:rawg)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-z]{32})\\b"]}
-{"name":"RazorpayApiKey","patterns":["(?i)\\brzp_\\w{2,6}_\\w{10,20}\\b"]}
-{"name":"RazorpayApiSecret","patterns":["(?:razor|secret|rzp|key)[-\\w]*[\\\" :=']*([A-Za-z0-9]{20,50})"]}
-{"name":"ReachmailApiKey","patterns":["(?i)(?:reachmail)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-_]{64})\\b"]}
-{"name":"ReadmeApiKey","patterns":["(?i)(?:readme)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]{32})\\b"]}
-{"name":"ReadmeApiToken","patterns":["(?i)\\b(rdme_[a-z0-9]{70})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"ReallysimplesystemApiKey","patterns":["\\b(ey[a-zA-Z0-9-._]{153}.ey[a-zA-Z0-9-._]{916,1000})\\b"]}
-{"name":"RebrandlyApiKey","patterns":["(?i)(?:rebrandly)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]{32})\\b"]}
-{"name":"RefinerApiKey","patterns":["(?i)(?:refiner)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b"]}
-{"name":"RentmanApiKey","patterns":["(?i)(?:rentman)(?:.|[\\n\\r]){0,40}\\b(ey[a-zA-Z0-9]{34}.ey[a-zA-Z0-9._-]{250,300})\\b"]}
-{"name":"RepairshoprApiKey","patterns":["(?i)(?:repairshopr)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-]{51})\\b"]}
-{"name":"RestpackApiKey","patterns":["(?i)(?:restpack)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{48})\\b"]}
-{"name":"RevApiClientKey","patterns":["(?i)(?:rev)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z\\-]{27}[ \\r\\n]{1})"]}
-{"name":"RevApiUserKey","patterns":["(?i)(?:rev)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z\\\/\\+]{27}\\=[ \\r\\n]{1})"]}
-{"name":"RevampApiKey","patterns":["(?i)(?:revamp)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{40}\\b)"]}
-{"name":"RingcentralApiKey","patterns":["(?i)(?:ringcentral)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z_-]{22})\\b"]}
-{"name":"RitekitApiKey","patterns":["(?i)(?:ritekit)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{44})\\b"]}
-{"name":"RoaringApiSecret","patterns":["(?i)(?:roaring)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z_-]{28})\\b"]}
-{"name":"RocketreachApiKey","patterns":["(?i)(?:rocketreach)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{39})\\b"]}
-{"name":"RocksetApiKey","patterns":["(?i)(?:rockset)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{64})\\b"]}
-{"name":"RoninApiKey","patterns":["(?i)(?:ronin)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{26})\\b"]}
-{"name":"Route4MeApiKey","patterns":["(?i)(?:route4me)(?:.|[\\n\\r]){0,40}\\b([0-9A-Z]{32})\\b"]}
-{"name":"RowndApiKey","patterns":["(?i)(?:rownd)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{8}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{12})\\b"]}
-{"name":"RowndApiSecret","patterns":["(?i)(?:rownd)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{48})\\b"]}
-{"name":"RubygemsApiKey","patterns":["\\b(rubygems_[a-zA0-9]{48})\\b"]}
-{"name":"RubygemsApiToken","patterns":["(?i)\\b(rubygems_[a-f0-9]{48})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"RunrunitApiKey","patterns":["(?i)(?:runrunit)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{32})\\b"]}
-{"name":"RunrunitApiUserToken","patterns":["(?i)(?:runrunit)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{18,20})\\b"]}
-{"name":"SalesblinkApiKey","patterns":["(?i)(?:salesblink)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z]{16})\\b"]}
-{"name":"SalescookieApiKey","patterns":["(?i)(?:salescookie)(?:.|[\\n\\r]){0,40}\\b([a-zA-z0-9]{32})\\b"]}
-{"name":"SalesflareApiKey","patterns":["(?i)(?:salesflare)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]{45})\\b"]}
-{"name":"SatismeterApiKey","patterns":["(?i)(?:satismeter)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{24})\\b"]}
-{"name":"SatismeterApiPassword","patterns":["(?i)(?:satismeter)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9!=@#$%^]{6,32})"]}
-{"name":"SaucelabsApiKey","patterns":["(?i)(?:saucelabs)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{8}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{12})\\b"]}
-{"name":"ScalewayApiKey","patterns":["(?i)(?:scaleway)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b"]}
-{"name":"ScalingoApiToken","patterns":["\\btk-us-[a-zA-Z0-9-_]{48}\\b"]}
-{"name":"ScrapeowlApiKey","patterns":["(?i)(?:scrapeowl)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{30})\\b"]}
-{"name":"ScraperboxApiKey","patterns":["(?i)(?:scraperbox)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9]{32})\\b"]}
-{"name":"ScrapersiteApiKey","patterns":["(?i)(?:scrapersite)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{45})\\b"]}
-{"name":"ScraperstackApiKey","patterns":["(?i)(?:scrapestack)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"ScrapflyApiKey","patterns":["(?i)(?:scrapfly)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"ScrapingantApiKey","patterns":["(?i)(?:scrapingant)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"ScrapingbeeApiKey","patterns":["(?i)(?:scrapingbee)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9]{80})\\b"]}
-{"name":"ScrapperapiKey","patterns":["(?i)(?:scraperapi)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"ScreenshotapiKey","patterns":["(?i)(?:screenshotapi)(?:.|[\\n\\r]){0,40}\\b([0-9A-Z]{7}\\-[0-9A-Z]{7}\\-[0-9A-Z]{7}\\-[0-9A-Z]{7})\\b"]}
-{"name":"ScreenshotlayerApiKey","patterns":["(?i)(?:screenshotlayer)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_]{32})\\b"]}
-{"name":"ScrutinizerApiKey","patterns":["(?i)(?:scrutinizer)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{64})\\b"]}
-{"name":"SecuritytrailsApiKey","patterns":["(?i)(?:securitytrails)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"SegmentApiKey","patterns":["(?i)(?:segment)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_\\-a-zA-Z]{43}\\.[A-Za-z0-9_\\-a-zA-Z]{43})\\b"]}
-{"name":"SelectpdfApiKey","patterns":["(?i)(?:selectpdf)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"SemaphoreApiKey","patterns":["(?i)(?:semaphore)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"SendGridApiToken","patterns":["(?i)\\b(SG\\.[a-z0-9=_\\-\\.]{66})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"Sendbird","patterns":["(?i)(?:sendbird)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:sendbird)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-f0-9]{40})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"SendbirdApiKey","patterns":["(?i)(?:sendbird)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{40})\\b"]}
-{"name":"SendbirdOrganizationalApiKey","patterns":["(?i)(?:sendbird)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{24})\\b"]}
-{"name":"SendgridApiKey","patterns":["(?i)(?:sendgrid)(?:.|[\\n\\r]){0,40}(SG\\.[\\w\\-_]{20,24}\\.[\\w\\-_]{39,50})\\b"]}
-{"name":"SendinBlueApiToken","patterns":["(?i)\\b(xkeysib-[a-f0-9]{64}-[a-z0-9]{16})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"SendinblueApiKey","patterns":["\\b(xkeysib\\-[A-Za-z0-9_-]{81})\\b"]}
-{"name":"SentimentApiKey","patterns":["(?i)(?:sentiment)(?:.|[\\n\\r]){0,40}\\b([0-9]{17})\\b"]}
-{"name":"SentimentApiToken","patterns":["(?i)(?:sentiment)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{20})\\b"]}
-{"name":"SentryAccessToken","patterns":["(?i)(?:sentry)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-f0-9]{64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"SentryApiKey","patterns":["(?i)(?:sentry)(?:.|[\\n\\r]){0,40}\\b([a-f0-9]{64})\\b"]}
-{"name":"SerphouseApiKey","patterns":["(?i)(?:serphouse)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{60})\\b"]}
-{"name":"SerpstackApiKey","patterns":["(?i)(?:serpstack)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"SheetyApiKey","patterns":["(?i)(?:sheety)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{64})\\b"]}
-{"name":"SherpadeskApiKey","patterns":["(?i)(?:sherpadesk)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"ShipdayApiKey","patterns":["(?i)(?:shipday)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9.]{11}[a-zA-Z0-9]{20})\\b"]}
-{"name":"ShippoApiToken","patterns":["(?i)\\b(shippo_(live|test)_[a-f0-9]{40})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"ShodanApiKey","patterns":["(?i)(?:shodan)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"Shopify","patterns":["shpat_[a-fA-F0-9]{32}","shpca_[a-fA-F0-9]{32}","shppa_[a-fA-F0-9]{32}","shpss_[a-fA-F0-9]{32}"]}
-{"name":"ShortcutApiKey","patterns":["(?i)(?:shortcut)(?:.|[\\n\\r]){0,40}\\b([0-9a-f-]{36})\\b"]}
-{"name":"ShortstackApiKey","patterns":["(?i)(?:shotstack)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{40})\\b"]}
-{"name":"ShutterstockApiKey","patterns":["(?i)(?:shutterstock)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{32})\\b"]}
-{"name":"ShutterstockApiSecret","patterns":["(?i)(?:shutterstock)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{16})\\b"]}
-{"name":"ShutterstockOauthKey","patterns":["(?i)(?:shutterstock)(?:.|[\\n\\r]){0,40}\\b(v2\/[0-9A-Za-z]{388})\\b"]}
-{"name":"Sidekiq","patterns":["(?i)(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)\\b(http(?:s??):\\\/\\\/)([a-f0-9]{8}:[a-f0-9]{8})@(?:gems.contribsys.com|enterprise.contribsys.com)(?:[\\\/|\\#|\\?|:]|$)"]}
-{"name":"SignableApiKey","patterns":["(?i)(?:signable)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{32})\\b"]}
-{"name":"SignalwireApiKey","patterns":["(?i)(?:signalwire)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{50})\\b"]}
-{"name":"SignaturitApiKey","patterns":["(?i)(?:signaturit)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{86})\\b"]}
-{"name":"SignupgeniusApiKey","patterns":["(?i)(?:signupgenius)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{32})\\b"]}
-{"name":"SigoptApiKey","patterns":["(?i)(?:sigopt)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9]{48})\\b"]}
-{"name":"SimfinApiKey","patterns":["(?i)(?:simfin)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"SimplesatApiKey","patterns":["(?i)(?:simplesat)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{40})"]}
-{"name":"SimplynotedApiKey","patterns":["(?i)(?:simplynoted)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9\\S]{340,360})\\b"]}
-{"name":"SimvolyApiKey","patterns":["(?i)(?:simvoly)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{33})\\b"]}
-{"name":"SinchApiKey","patterns":["(?i)(?:sinch)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"SirvApiKey","patterns":["(?i)(?:sirv)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9\\S]{88})"]}
-{"name":"SiteleafApiKey","patterns":["(?i)(?:siteleaf)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-z]{32})\\b"]}
-{"name":"SkrappApiKey","patterns":["(?i)(?:skrapp)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{42})\\b"]}
-{"name":"SkybiometryApiKey","patterns":["(?i)(?:skybiometry)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{25,26})\\b"]}
-{"name":"Slack","patterns":["(?i)(xapp-\\d-[A-Z0-9]+-\\d+-[a-z0-9]+)","(?i)(xoxe-\\d-[A-Z0-9]{146})","(?i)(xoxe.xox[bp]-\\d-[A-Z0-9]{163,166})","(https?:\\\/\\\/)?hooks.slack.com\\\/(services|workflows)\\\/[A-Za-z0-9+\\\/]{43,46}","(xox[ar]-(?:\\d-)?[0-9a-zA-Z]{8,48})","(xox[os]-\\d+-\\d+-\\d+-[a-fA-F\\d]+)","(xox[pe](?:-[0-9]{10,13}){3}-[a-zA-Z0-9-]{28,34})","(xoxb-[0-9]{10,13}\\-[0-9]{10,13}[a-zA-Z0-9-]*)","(xoxb-[0-9]{8,14}\\-[a-zA-Z0-9]{18,26})"]}
-{"name":"SlackToken","patterns":["(xoxb|xoxp|xapp|xoxa|xoxr)\\-[0-9]{10,13}\\-[a-zA-Z0-9\\-]*"]}
-{"name":"SlackTokenV2","patterns":["xox[baprs]-([0-9a-zA-Z]{10,48})?"]}
-{"name":"SlackWebhook","patterns":["(https:\\\/\\\/hooks\\.slack\\.com\\\/services\\\/[A-Za-z0-9+\\\/]{44,46})"]}
-{"name":"SmartsheetsApiKey","patterns":["(?i)(?:smartsheets)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{37})\\b"]}
-{"name":"SmartystreetsApiKey","patterns":["(?i)(?:smartystreets)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{20})\\b"]}
-{"name":"SmoochApiKey","patterns":["(?i)(?:smooch)(?:.|[\\n\\r]){0,40}\\b(act_[0-9a-z]{24})\\b"]}
-{"name":"SnipcartApiKey","patterns":["(?i)(?:snipcart)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z_]{75})\\b"]}
-{"name":"SnykApiToken","patterns":["(?i)(?:snyk)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"Softlayer","patterns":["(?:(?<=\\W)|(?<=^))(?:\\[|)(?:\"|\\'|)(?:softlayer|sl)(?:_|-|)(?:api|)(?:_|-|)(?:key|pwd|password|pass|token)(?:\"|\\'|)(?:\\]|)(?: *)(?:=|:|:=|=>| +|::)(?: *)(?:\"|\\'|)([a-z0-9]{64})(?:\"|\\'|)","(?:http|https):\/\/api.softlayer.com\/soap\/(?:v3|v3.1)\/([a-z0-9]{64})"]}
-{"name":"SonarcloudApiKey","patterns":["(?i)(?:sonarcloud)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{40})\\b"]}
-{"name":"SparkpostApiKey","patterns":["\\b([a-zA-Z0-9]{40})\\b"]}
-{"name":"SplunkApiKey","patterns":["(?i)(?:splunk)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{22})\\b"]}
-{"name":"SpoonacularApiKey","patterns":["(?i)(?:spoonacular)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"SportradarApiKey","patterns":["(?i)(?:sportradar)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{24})\\b"]}
-{"name":"SportsmonkApiKey","patterns":["(?i)(?:sportsmonk)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{60})\\b"]}
-{"name":"SpotifyApiKey","patterns":["(?i)(?:secret|key)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9]{32})\\b"]}
-{"name":"SquareAccessToken","patterns":["sq0atp-[0-9A-Za-z\\-_]{22}"]}
-{"name":"SquareApiKey","patterns":["(?i)(?:square)(?:.|[\\n\\r]){0,40}(EAAA[a-zA-Z0-9\\-\\+\\=]{60})"]}
-{"name":"SquareOAuth","patterns":["sq0csp-[0-9A-Za-z\\\\\\-_]{43}"]}
-{"name":"SquareOauthSecret","patterns":["sq0csp-[0-9A-Za-z\\-_]{43}"]}
-{"name":"SquareappApiKey","patterns":["[\\w\\-]*sq0i[a-z]{2}-[0-9A-Za-z\\-_]{22,43}"]}
-{"name":"SquareappApiSecret","patterns":["[\\w\\-]*sq0c[a-z]{2}-[0-9A-Za-z\\-_]{40,50}"]}
-{"name":"SquarespaceAccessToken","patterns":["(?i)(?:squarespace)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"SquarespaceApiKey","patterns":["(?i)(?:squarespace)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b"]}
-{"name":"SquareupApiKey","patterns":["\\b(sq0idp-[0-9A-Za-z]{22})\\b"]}
-{"name":"SslmateApiKey","patterns":["(?i)(?:sslmate)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{36})\\b"]}
-{"name":"StatuscakeApiKey","patterns":["(?i)(?:statuscake)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{20})\\b"]}
-{"name":"StatuspageApiKey","patterns":["(?i)(?:statuspage)(?:.|[\\n\\r]){0,40}\\b([0-9a-z-]{36})\\b"]}
-{"name":"StatuspalApiKey","patterns":["(?i)(?:statuspal)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{32})\\b"]}
-{"name":"StitchdataApiKey","patterns":["(?i)(?:stitchdata)(?:.|[\\n\\r]){0,40}\\b([0-9a-z_]{35})\\b"]}
-{"name":"StockdataApiKey","patterns":["(?i)(?:stockdata)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{40})\\b"]}
-{"name":"StorecoveApiKey","patterns":["(?i)(?:storecove)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_-]{43})\\b"]}
-{"name":"StormboardApiKey","patterns":["(?i)(?:stormboard)(?:.|[\\n\\r]){0,40}\\b([a-f0-9]{40})\\b"]}
-{"name":"StormglassApiKey","patterns":["(?i)(?:stormglass)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-z-]{73})\\b"]}
-{"name":"StoryblokApiKey","patterns":["(?i)(?:storyblok)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{22}t{2})\\b"]}
-{"name":"StorychiefApiKey","patterns":["(?i)(?:storychief)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_\\-.]{940,1000})"]}
-{"name":"StravaApiKey","patterns":["(?i)(?:strava)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{40})\\b"]}
-{"name":"StreakApiKey","patterns":["(?i)(?:streak)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-f]{32})\\b"]}
-{"name":"Stripe","patterns":["(?:r|s)k_live_[0-9a-zA-Z]{24}"]}
-{"name":"StripeApiKey","patterns":["[rs]k_live_[a-zA-Z0-9]{20,30}"]}
-{"name":"StytchApiKey","patterns":["(?i)(?:stytch)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-_]{47}=)"]}
-{"name":"SugesterApiDomain","patterns":["(?i)(?:sugester)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_.!+$#^*%]{3,32})\\b"]}
-{"name":"SugesterApiKey","patterns":["(?i)(?:sugester)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"SumoApiKey","patterns":["(?i)(?:sumo)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9]{64})\\b"]}
-{"name":"SumoLogic","patterns":["(?i)(?:sumo)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{64})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i:(?:sumo)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3})(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(su[a-zA-Z0-9]{12})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"SupernotesApiKey","patterns":["(?i)(?:supernotes)(?:.|[\\n\\r]){0,40}([ \\r\\n]{0,1}[0-9A-Za-z\\-_]{43}[ \\r\\n]{1})"]}
-{"name":"SurveyApiKey","patterns":["(?i)(?:survey)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{32})\\b"]}
-{"name":"SurveybotApiKey","patterns":["(?i)(?:surveybot)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9-]{80})\\b"]}
-{"name":"SurveysparrowApiKey","patterns":["(?i)(?:surveysparrow)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-_]{88})\\b"]}
-{"name":"SurvicateApiKey","patterns":["(?i)(?:survicate)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"SwellApiKey","patterns":["(?i)(?:swell)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"SwiftypeApiKey","patterns":["(?i)(?:swiftype)(?:.|[\\n\\r]){0,40}\\b([a-zA-z-0-9]{6}\\_[a-zA-z-0-9]{6}\\-[a-zA-z-0-9]{6})\\b"]}
-{"name":"SynkApiKey","patterns":["(?i)(?:snyk)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b"]}
-{"name":"TallyfyApiKey","patterns":["(?i)(?:tallyfy)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{36}\\.[0-9A-Za-z]{264}\\.[0-9A-Za-z\\-\\_]{683})\\b"]}
-{"name":"TatumApiKey","patterns":["(?i)(?:tatum)(?:.|[\\n\\r]){0,40}\\b([0-9a-z-]{36})\\b"]}
-{"name":"TaxjarApiKey","patterns":["(?i)(?:taxjar)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"TeamgateApiKey","patterns":["(?i)(?:teamgate)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{80})\\b"]}
-{"name":"TeamgateApiToken","patterns":["(?i)(?:teamgate)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{40})\\b"]}
-{"name":"TeamworkcrmApiKey","patterns":["(?i)(?:teamwork|teamworkcrm|teamworkdesk|teamworkspaces)(?:.|[\\n\\r]){0,40}\\b(tkn\\.v1_[0-9A-Za-z]{71}=[ \\r\\n]{1})"]}
-{"name":"TechnicalanalysisapiKey","patterns":["(?i)(?:technicalanalysisapi)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9]{48})\\b"]}
-{"name":"TefterApiKey","patterns":["(?i)(?:tefter)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{20})\\b"]}
-{"name":"TelegramApiToken","patterns":["(?i)(?:telegram)(?:.|[\\n\\r]){0,40}\\b([0-9]{8,10}:[a-zA-Z0-9_-]{35})\\b"]}
-{"name":"TelegramBotApiToken","patterns":["(?i)(?:^|[^0-9])([0-9]{5,16}:A[a-zA-Z0-9_\\-]{34})(?:$|[^a-zA-Z0-9_\\-])"]}
-{"name":"TelenyxApiKey","patterns":["(?i)(?:telnyx)(?:.|[\\n\\r]){0,40}\\b(KEY[0-9A-Za-z_-]{55})\\b"]}
-{"name":"TeletypeApiKey","patterns":["(?i)(?:teletype)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z-]{64})\\b"]}
-{"name":"TerraformcloudApiToken","patterns":["\\b([A-Za-z0-9]{14}.atlasv1.[A-Za-z0-9]{67})\\b"]}
-{"name":"TestingbotApiKey","patterns":["(?i)(?:testingbot)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"Text2DataApiKey","patterns":["(?i)(?:text2data)(?:.|[\\n\\r]){0,40}\\b([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})\\b"]}
-{"name":"TextmagicApiKey","patterns":["(?i)(?:textmagic)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{30})\\b"]}
-{"name":"TheoddsapiKey","patterns":["(?i)(?:theoddsapi|the-odds-api)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{32})\\b"]}
-{"name":"ThinkificApiKey","patterns":["(?i)(?:thinkific)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{32})\\b"]}
-{"name":"ThousandeyesApiKey","patterns":["(?i)(?:thousandeyes)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"TicketmasterApiKey","patterns":["(?i)(?:ticketmaster)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"TickettailorApiKey","patterns":["(?i)(?:tickettailor)(?:.|[\\n\\r]){0,40}\\b(sk[a-fA-Z0-9_]{45})\\b"]}
-{"name":"TiingoApiKey","patterns":["(?i)(?:tiingo)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{40})\\b"]}
-{"name":"TimecampApiKey","patterns":["(?i)(?:timecamp)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{26})\\b"]}
-{"name":"TimezoneApiKey","patterns":["(?i)(?:timezoneapi)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{20})\\b"]}
-{"name":"TlyApiKey","patterns":["(?i)(?:tly)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{60})\\b"]}
-{"name":"TmetricApiKey","patterns":["(?i)(?:tmetric)(?:.|[\\n\\r]){0,40}\\b([0-9A-Z]{64})\\b"]}
-{"name":"TodoistApiKey","patterns":["(?i)(?:todoist)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{40})\\b"]}
-{"name":"ToggltrackApiKey","patterns":["(?i)(?:toggl)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-z]{32})\\b"]}
-{"name":"TomorrowApiKey","patterns":["(?i)(?:tomorrow)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"TomtomApiKey","patterns":["(?i)(?:tomtom)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-zA-Z]{32})\\b"]}
-{"name":"TradierApiKey","patterns":["(?i)(?:tradier)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{28})\\b"]}
-{"name":"TravelpayoutsApiKey","patterns":["(?i)(?:travelpayouts)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"TravisCiAccessToken","patterns":["(?i)(?:travis)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{22})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"TravisciApiKey","patterns":["(?i)(?:travis)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9A-Z_]{22})\\b"]}
-{"name":"TrelloApiKey","patterns":["(?i)(?:trello)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z-0-9]{32})\\b"]}
-{"name":"TruApiKey","patterns":["(?i)(?:tru)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b"]}
-{"name":"TruApiSecret","patterns":["(?i)(?:tru)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z.-_]{26})\\b"]}
-{"name":"TwelvedataApiKey","patterns":["(?i)(?:twelvedata)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"TwilioKey","patterns":["AC[a-z0-9]{32}","SK[a-z0-9]{32}"]}
-{"name":"TwilloApiKey","patterns":["(?i)(?:twillo)(?:.|[\\n\\r]){0,40}\\bSK[0-9a-fA-F]{32}\\b"]}
-{"name":"TwitchApiKey","patterns":["(?i)(?:twitch)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{30})\\b"]}
-{"name":"TwitchApiToken","patterns":["(?i)(?:twitch)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{30})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"Twitter","patterns":["(?i)(?:twitter)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:twitter)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:twitter)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{25})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:twitter)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{45})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:twitter)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{50})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"TwitterAccessToken","patterns":["(?i)(?:twitter)(?:.|[\\n\\r]){0,40}\\b[1-9][0-9]+-[0-9a-zA-Z]{40}\\b"]}
-{"name":"TwitterApiKey","patterns":["(?i)(?:twitter)(?:.|[\\n\\r]){0,40}\\b([A-Z]{22}%[a-zA-Z-0-9]{23}%[a-zA-Z-0-9]{6}%[a-zA-Z-0-9]{3}%[a-zA-Z-0-9]{9}%[a-zA-Z-0-9]{52})\\b"]}
-{"name":"TyntecApiKey","patterns":["(?i)(?:tyntec)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{32})\\b"]}
-{"name":"TypeformApiKey","patterns":["(?i)(?:typeform)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{44})\\b"]}
-{"name":"TypeformApiToken","patterns":["(?i)(?:typeform)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(tfp_[a-z0-9\\-_\\.=]{59})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"TypetalkApiKey","patterns":["(?i)(?:typetalk)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{64})\\b"]}
-{"name":"UbidotsApiKey","patterns":["\\b(BBFF-[0-9a-zA-Z]{30})\\b"]}
-{"name":"UclassifyApiKey","patterns":["(?i)(?:uclassify)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{12})\\b"]}
-{"name":"UnifyApiKey","patterns":["(?i)(?:unify)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z_=-]{44})"]}
-{"name":"UnpluggApiKey","patterns":["(?i)(?:unplu)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{64})\\b"]}
-{"name":"UnsplashApiKey","patterns":["(?i)(?:unsplash)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z_]{43})\\b"]}
-{"name":"UpcdatabaseApiKey","patterns":["(?i)(?:upcdatabase)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9]{32})\\b"]}
-{"name":"UpleadApiKey","patterns":["(?i)(?:uplead)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{32})\\b"]}
-{"name":"UploadcareApiKey","patterns":["(?i)(?:uploadcare)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{20})\\b"]}
-{"name":"UptimerobotApiKey","patterns":["(?i)(?:uptimerobot)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{9}-[a-zA-Z0-9]{24})\\b"]}
-{"name":"UpwaveApiKey","patterns":["(?i)(?:upwave)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"Uri","patterns":["\\b[a-zA-Z]{1,10}:?\\\/\\\/[-.%\\w{}]{1,50}:([-.%\\S]{3,50})@[-.%\\w\\\/:]+\\b"]}
-{"name":"UrlscanApiKey","patterns":["(?i)(?:urlscan)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"UsdaGovApiKey","patterns":["(?i)(?:data.gov)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{40})\\b"]}
-{"name":"UserflowApiKey","patterns":["(?i)(?:userflow)(?:.|[\\n\\r]){0,40}\\b([0-9a-z_]{29})\\b"]}
-{"name":"UsersecretscannerApiKey","patterns":["(?i)(?:user)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-._+=]{64})\\b"]}
-{"name":"UserstackApiKey","patterns":["(?i)(?:userstack)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"VatlayerApiKey","patterns":["(?i)(?:vatlayer)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"Vault","patterns":["(?i)\\b(hvb\\.[a-z0-9_-]{138,212})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)\\b(hvs\\.[a-z0-9_-]{90,100})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"VboutApiKey","patterns":["(?i)(?:vbout)(?:.|[\\n\\r]){0,40}\\b([0-9]{25})\\b"]}
-{"name":"VercelApiKey","patterns":["(?i)(?:vercel)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{24})\\b"]}
-{"name":"VerifierApiKey","patterns":["(?i)(?:verifier)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{96})\\b"]}
-{"name":"VerimailApiKey","patterns":["(?i)(?:verimail)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9]{32})\\b"]}
-{"name":"VeriphoneApiKey","patterns":["(?i)(?:veriphone)(?:.|[\\n\\r]){0,40}\\b([0-9A-Z]{32})\\b"]}
-{"name":"VersioneyeApiKey","patterns":["(?i)(?:versioneye)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-]{40})\\b"]}
-{"name":"ViewneoApiKey","patterns":["(?i)(?:viewneo)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{120,300}.[a-z0-9A-Z]{150,300}.[a-z0-9A-Z-_]{600,800})"]}
-{"name":"VirustotalApiKey","patterns":["(?i)(?:virustotal)(?:.|[\\n\\r]){0,40}\\b([a-f0-9]{64})\\b"]}
-{"name":"VisualcrossingApiKey","patterns":["(?i)(?:visualcrossing)(?:.|[\\n\\r]){0,40}\\b([0-9A-Z]{25})\\b"]}
-{"name":"VoiceagainApiKey","patterns":["(?i)(?:voicegain)(?:.|[\\n\\r]){0,40}\\b(ey[0-9a-zA-Z_-]{34}.ey[0-9a-zA-Z_-]{108}.[0-9a-zA-Z_-]{43})\\b"]}
-{"name":"VoodoosmsApiKey","patterns":["(?i)(?:voodoosms)(?:.|[\\n\\r]){0,40}\\b([0-9a-zA-Z]{46})\\b"]}
-{"name":"VoucheryApiKey","patterns":["(?i)(?:vouchery)(?:.|[\\n\\r]){0,40}\\b([a-z0-9-]{36})\\b"]}
-{"name":"VpnapiKey","patterns":["(?i)(?:vpnapi)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z]{32})\\b"]}
-{"name":"VultrApiKey","patterns":["(?i)(?:vultr)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9]{36})\\b"]}
-{"name":"VyteApiKey","patterns":["(?i)(?:vyte)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{50})\\b"]}
-{"name":"WalkscoreApiKey","patterns":["(?i)(?:walkscore)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"WandbAPIKey","patterns":["\\b[a-f0-9]{40}\\b"]}
-{"name":"WeatherbitApiKey","patterns":["(?i)(?:weatherbit)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"WeatherstackApiKey","patterns":["(?i)(?:weatherstack)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"WebexApiKey","patterns":["(?i)(?:webex)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9_-]{64})\\b"]}
-{"name":"WebflowApiKey","patterns":["(?i)(?:webflow)(?:.|[\\n\\r]){0,40}\\b([a-zA0-9]{64})\\b"]}
-{"name":"WebscraperApiKey","patterns":["(?i)(?:webscraper)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{60})\\b"]}
-{"name":"WebscrapingApiKey","patterns":["(?i)(?:webscraping)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{32})\\b"]}
-{"name":"WepayApiKey","patterns":["(?i)(?:wepay)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_?]{62})\\b"]}
-{"name":"WhoxyApiKey","patterns":["(?i)(?:whoxy)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{33})\\b"]}
-{"name":"WistiaApiKey","patterns":["(?i)(?:wistia)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{64})\\b"]}
-{"name":"WitApiKey","patterns":["(?i)(?:wit)(?:.|[\\n\\r]){0,40}\\b([A-Z0-9]{32})\\b"]}
-{"name":"WorksnapsApiKey","patterns":["(?i)(?:worksnaps)(?:.|[\\n\\r]){0,40}\\b([0-9A-Za-z]{40})\\b"]}
-{"name":"WorkstackApiKey","patterns":["(?i)(?:workstack)(?:.|[\\n\\r]){0,40}\\b([0-9Aa-zA-Z]{60})\\b"]}
-{"name":"WorldcoinindexApiKey","patterns":["(?i)(?:worldcoinindex)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{35})\\b"]}
-{"name":"WorlweatherApiKey","patterns":["(?i)(?:worldweather)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{31})\\b"]}
-{"name":"WrikeApiKey","patterns":["(?i)(?:wrike)(?:.|[\\n\\r]){0,40}\\b(ey[a-zA-Z0-9-._]{333})\\b"]}
-{"name":"Yandex","patterns":["(?i)(?:yandex)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(AQVN[A-Za-z0-9_\\-]{35,38})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:yandex)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(YC[a-zA-Z0-9_\\-]{38})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)","(?i)(?:yandex)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}(t1\\.[A-Z0-9a-z_-]+[=]{0,2}\\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"YandexApiKey","patterns":["(?i)(?:yandex)(?:.|[\\n\\r]){0,40}\\b([a-z0-9A-Z.]{83})\\b"]}
-{"name":"YelpApiKey","patterns":["(?i)(?:yelp)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9_\\\\=\\.\\-]{128})\\b"]}
-{"name":"YouneedabudgetApiKey","patterns":["(?i)(?:youneedabudget)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{64})\\b"]}
-{"name":"YousignApiKey","patterns":["(?i)(?:yousign)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"Youtube\/GoogleApiKey","patterns":["(?i)(?:youtube)(?:.|[\\n\\r]){0,40}\\bAIza[0-9A-Za-z\\-_]{35}\\b"]}
-{"name":"Youtube\/GoogleOauthId","patterns":["[0-9]+-[0-9A-Za-z_]{32}\\.apps\\.googleusercontent\\.com"]}
-{"name":"ZapierWebhook","patterns":["(https:\\\/\\\/hooks\\.zapier\\.com\\\/hooks\\\/catch\\\/[A-Za-z0-9\\\/]{16})"]}
-{"name":"ZendeskApiToken","patterns":["(?i)(?:zendesk)(?:.|[\\n\\r]){0,40}([A-Za-z0-9_-]{40})"]}
-{"name":"ZendeskSecretKey","patterns":["(?i)(?:zendesk)(?:[0-9a-z\\-_\\t .]{0,20})(?:[\\s|']|[\\s|\"]){0,3}(?:=|>|:{1,3}=|\\|\\|:|<=|=>|:|\\?=)(?:'|\\\"|\\s|=|\\x60){0,5}([a-z0-9]{40})(?:['|\\\"|\\n|\\r|\\s|\\x60|;]|$)"]}
-{"name":"ZenkitApiKey","patterns":["(?i)(?:zenkit)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{8}\\-[0-9A-Za-z]{32})\\b"]}
-{"name":"ZenrowsApiKey","patterns":["(?i)(?:zenrows)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{40})\\b"]}
-{"name":"ZenscrapeApiKey","patterns":["(?i)(?:zenscrape)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b"]}
-{"name":"ZenserpApiKey","patterns":["(?i)(?:zenserp)(?:.|[\\n\\r]){0,40}\\b([0-9a-z-]{36})\\b"]}
-{"name":"ZeplinApiKey","patterns":["(?i)(?:zeplin)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9-.]{350,400})\\b"]}
-{"name":"ZerobounceApiKey","patterns":["(?i)(?:zerobounce)(?:.|[\\n\\r]){0,40}\\b([a-z0-9]{32})\\b"]}
-{"name":"ZipapiKey","patterns":["(?i)(?:zipapi)(?:.|[\\n\\r]){0,40}\\b([0-9a-z]{32})\\b"]}
-{"name":"ZipapiPassword","patterns":["(?i)(?:zipapi)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9!=@#$%^]{7,})"]}
-{"name":"ZipbooksPassword","patterns":["(?i)(?:zipbooks|password)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9!=@#$%^]{8,})"]}
-{"name":"ZipcodeApiKey","patterns":["(?i)(?:zipcodeapi)(?:.|[\\n\\r]){0,40}\\b([a-zA-Z0-9]{64})\\b"]}
-{"name":"ZipcodebaseApiKey","patterns":["(?i)(?:zipcodebase)(?:.|[\\n\\r]){0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b"]}
-{"name":"ZonkaApiKey","patterns":["(?i)(?:zonka)(?:.|[\\n\\r]){0,40}\\b([A-Za-z0-9]{36})\\b"]}
+{"name":"Abbysale","regex":"(?:abbysale).{0,40}\\b([a-z0-9A-Z]{40})\\b","confidence":"high"}
+{"name":"Abstract","regex":"(?:abstract).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Abuseipdb","regex":"(?:abuseipdb).{0,40}\\b([a-z0-9]{80})\\b","confidence":"high"}
+{"name":"AccessKeySecret","regex":"access[_-]?key[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AccessSecret","regex":"access[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AccessToken","regex":"access[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AccountSid","regex":"account[_-]?sid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Accuweather","regex":"(?:accuweather).{0,40}([a-z0-9A-Z\\%]{35})\\b","confidence":"high"}
+{"name":"Adafruitio","regex":"\\b(aio\\_[a-zA-Z0-9]{28})\\b","confidence":"high"}
+{"name":"AdminEmail","regex":"admin[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Adobeio1","regex":"(?:adobe).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"AdzerkApiKey","regex":"adzerk[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Adzuna1","regex":"(?:adzuna).{0,40}\\b([a-z0-9]{8})\\b","confidence":"high"}
+{"name":"Adzuna2","regex":"(?:adzuna).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Aeroworkflow1","regex":"(?:aeroworkflow).{0,40}\\b([0-9]{1,})\\b","confidence":"high"}
+{"name":"Aeroworkflow2","regex":"(?:aeroworkflow).{0,40}\\b([a-zA-Z0-9^!]{20})\\b","confidence":"high"}
+{"name":"Agora","regex":"(?:agora).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Airbrakeprojectkey1","regex":"(?:airbrake).{0,40}\\b([0-9]{6})\\b","confidence":"high"}
+{"name":"Airbrakeprojectkey2","regex":"(?:airbrake).{0,40}\\b([a-zA-Z-0-9]{32})\\b","confidence":"high"}
+{"name":"Airbrakeuserkey","regex":"(?:airbrake).{0,40}\\b([a-zA-Z-0-9]{40})\\b","confidence":"high"}
+{"name":"Airship","regex":"(?:airship).{0,40}\\b([0-9Aa-zA-Z]{91})\\b","confidence":"high"}
+{"name":"Airvisual","regex":"(?:airvisual).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"Alconost","regex":"(?:alconost).{0,40}\\b([0-9Aa-z]{32})\\b","confidence":"high"}
+{"name":"Alegra1","regex":"(?:alegra).{0,40}\\b([a-z0-9-]{20})\\b","confidence":"high"}
+{"name":"Alegra2","regex":"(?:alegra).{0,40}\\b([a-zA-Z0-9.-@]{25,30})\\b","confidence":"high"}
+{"name":"Aletheiaapi","regex":"(?:aletheiaapi).{0,40}\\b([A-Z0-9]{32})\\b","confidence":"high"}
+{"name":"AlgoliaAdminKey1","regex":"algolia[_-]?admin[_-]?key[_-]?1(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AlgoliaAdminKey2","regex":"algolia[_-]?admin[_-]?key[_-]?2(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AlgoliaAdminKeyMcm","regex":"algolia[_-]?admin[_-]?key[_-]?mcm(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AlgoliaApiKey","regex":"algolia[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AlgoliaApiKeyMcm","regex":"algolia[_-]?api[_-]?key[_-]?mcm(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AlgoliaApiKeySearch","regex":"algolia[_-]?api[_-]?key[_-]?search(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AlgoliaSearchApiKey","regex":"algolia[_-]?search[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AlgoliaSearchKey","regex":"algolia[_-]?search[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AlgoliaSearchKey1","regex":"algolia[_-]?search[_-]?key[_-]?1(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Algoliaadminkey1","regex":"(?:algolia).{0,40}\\b([A-Z0-9]{10})\\b","confidence":"low"}
+{"name":"Algoliaadminkey2","regex":"(?:algolia).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"low"}
+{"name":"AliasPass","regex":"alias[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Alibaba2","regex":"\\b(LTAI[a-zA-Z0-9]{17,21})[\\\"' ;\\s]*","confidence":"high"}
+{"name":"AlicloudAccessKey","regex":"alicloud[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AlicloudSecretKey","regex":"alicloud[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Alienvault","regex":"(?:alienvault).{0,40}\\b([a-z0-9]{64})\\b","confidence":"high"}
+{"name":"Allsports","regex":"(?:allsports).{0,40}\\b([0-9a-z]{64})\\b","confidence":"high"}
+{"name":"Amadeus1","regex":"(?:amadeus).{0,40}\\b([0-9A-Za-z]{32})\\b","confidence":"high"}
+{"name":"Amadeus2","regex":"(?:amadeus).{0,40}\\b([0-9A-Za-z]{16})\\b","confidence":"high"}
+{"name":"AmazonBucketName","regex":"amazon[_-]?bucket[_-]?name(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AmazonSecretAccessKey","regex":"amazon[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"AmazonSnsTopic","regex":"arn:aws:sns:[a-z0-9\\-]+:[0-9]+:[A-Za-z0-9\\-_]+","confidence":"low"}
+{"name":"Ambee","regex":"(?:ambee).{0,40}\\b([0-9a-f]{64})\\b","confidence":"high"}
+{"name":"Amplitudeapikey","regex":"(?:amplitude).{0,40}\\b([a-f0-9]{32})","confidence":"high"}
+{"name":"AnacondaToken","regex":"anaconda[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AndroidDocsDeployToken","regex":"android[_-]?docs[_-]?deploy[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AnsibleVaultPassword","regex":"ansible[_-]?vault[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"AnthropicApiKey","regex":"\\bsk-ant-api0[3-4]-[A-Za-z0-9_-]{80,}\\b","confidence":"high"}
+{"name":"AosKey","regex":"aos[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AosSec","regex":"aos[_-]?sec(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Apacta","regex":"(?:apacta).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"Api2Cart","regex":"(?:api2cart).{0,40}\\b([0-9a-f]{32})\\b","confidence":"high"}
+{"name":"ApiKey","regex":"api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ApiKeySecret","regex":"api[_-]?key[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ApiKeySid","regex":"api[_-]?key[_-]?sid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ApiSecret","regex":"api[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ApiaryApiKey","regex":"apiary[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Apideck1","regex":"\\b(sk_live_[a-z0-9A-Z-]{93})\\b","confidence":"high"}
+{"name":"Apideck2","regex":"(?:apideck).{0,40}\\b([a-z0-9A-Z]{40})\\b","confidence":"high"}
+{"name":"Apiflash1","regex":"(?:apiflash).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Apiflash2","regex":"(?:apiflash).{0,40}\\b([a-zA-Z0-9\\S]{21,30})\\b","confidence":"high"}
+{"name":"Apifonica","regex":"(?:apifonica).{0,40}\\b([0-9a-z]{11}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b","confidence":"high"}
+{"name":"Apify","regex":"\\b(apify\\_api\\_[a-zA-Z-0-9]{36})\\b","confidence":"high"}
+{"name":"ApigwAccessToken","regex":"apigw[_-]?access[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ApikeyPatterns","regex":"apikey[:](?:['\"]?[a-zA-Z0-9-_|]+['\"]?)","confidence":"low"}
+{"name":"Apimatic1","regex":"(?:apimatic).{0,40}\\b([a-z0-9-\\S]{8,32})\\b","confidence":"high"}
+{"name":"Apimatic2","regex":"(?:apimatic).{0,40}\\b([a-zA-Z0-9]{3,20}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,5})\\b","confidence":"high"}
+{"name":"Apiscience","regex":"(?:apiscience).{0,40}\\b([a-bA-Z0-9\\S]{22})\\b","confidence":"high"}
+{"name":"Apollo","regex":"(?:apollo).{0,40}\\b([a-zA-Z0-9]{22})\\b","confidence":"high"}
+{"name":"AppBucketPerm","regex":"app[_-]?bucket[_-]?perm(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AppReportTokenKey","regex":"app[_-]?report[_-]?token[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AppSecrete","regex":"app[_-]?secrete(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AppToken","regex":"app[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Appclientsecret","regex":"appclientsecret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Appcues1","regex":"(?:appcues).{0,40}\\b([0-9]{5})\\b","confidence":"high"}
+{"name":"Appcues2","regex":"(?:appcues).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"Appcues3","regex":"(?:appcues).{0,40}\\b([a-z0-9-]{39})\\b","confidence":"high"}
+{"name":"Appfollow","regex":"(?:appfollow).{0,40}\\b([0-9A-Za-z]{20})\\b","confidence":"high"}
+{"name":"AppleIdPassword","regex":"apple[_-]?id[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Appsynergy","regex":"(?:appsynergy).{0,40}\\b([a-z0-9]{64})\\b","confidence":"high"}
+{"name":"Apptivo1","regex":"(?:apptivo).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"Apptivo2","regex":"(?:apptivo).{0,40}\\b([a-zA-Z0-9-]{32})\\b","confidence":"high"}
+{"name":"ArgosToken","regex":"argos[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Artifactory","regex":"(artifactory.{0,50}(\"|')?[a-zA-Z0-9=]{112}(\"|')?)","confidence":"low"}
+{"name":"Artifactory2","regex":"\\b([A-Za-z0-9](?:[A-Za-z0-9\\-]{0,61}[A-Za-z0-9])\\.jfrog\\.io)","confidence":"high"}
+{"name":"ArtifactoryApiToken","regex":"(?:\\s|=|:|\"|^)AKC[a-zA-Z0-9]{10,}","confidence":"low"}
+{"name":"ArtifactoryKey","regex":"artifactory[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ArtifactoryPassword","regex":"(?:\\s|=|:|\"|^)AP[\\dABCDEF][a-zA-Z0-9]{8,}","confidence":"low"}
+{"name":"ArtifactsAwsAccessKeyId","regex":"artifacts[_-]?aws[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ArtifactsAwsSecretAccessKey","regex":"artifacts[_-]?aws[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ArtifactsBucket","regex":"artifacts[_-]?bucket(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ArtifactsKey","regex":"artifacts[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ArtifactsSecret","regex":"artifacts[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Artsy1","regex":"(?:artsy).{0,40}\\b([0-9a-zA-Z]{20})\\b","confidence":"high"}
+{"name":"Artsy2","regex":"(?:artsy).{0,40}\\b([0-9a-zA-Z]{32})\\b","confidence":"high"}
+{"name":"Asanaoauth","regex":"(?:asana).{0,40}\\b([a-z\\\/:0-9]{51})\\b","confidence":"high"}
+{"name":"Asanapersonalaccesstoken","regex":"(?:asana).{0,40}\\b([0-9]{1,}\\\/[0-9]{16,}:[A-Za-z0-9]{32,})\\b","confidence":"high"}
+{"name":"Assemblyai","regex":"(?:assemblyai).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"AssistantIamApikey","regex":"assistant[_-]?iam[_-]?apikey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AsymmetricPrivateKey","regex":"-----BEGIN ((EC|PGP|DSA|RSA|OPENSSH) )?PRIVATE KEY( BLOCK)?-----","confidence":"high"}
+{"name":"Audd","regex":"(?:audd).{0,40}\\b([a-z0-9-]{32})\\b","confidence":"high"}
+{"name":"Auth0ApiClientsecret","regex":"auth0[_-]?api[_-]?clientsecret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Auth0ClientSecret","regex":"auth0[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Auth0Managementapitoken","regex":"(?:auth0).{0,40}\\b(ey[a-zA-Z0-9._-]+)\\b","confidence":"high"}
+{"name":"Auth0Oauth1","regex":"(?:auth0).{0,40}\\b([a-zA-Z0-9_-]{32,60})\\b","confidence":"low"}
+{"name":"AuthToken","regex":"auth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AuthorEmailAddr","regex":"author[_-]?email[_-]?addr(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AuthorNpmApiKey","regex":"author[_-]?npm[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Autodesk1","regex":"(?:autodesk).{0,40}\\b([0-9A-Za-z]{32})\\b","confidence":"high"}
+{"name":"Autodesk2","regex":"(?:autodesk).{0,40}\\b([0-9A-Za-z]{16})\\b","confidence":"high"}
+{"name":"Autoklose","regex":"(?:autoklose).{0,40}\\b([a-zA-Z0-9-]{32})\\b","confidence":"high"}
+{"name":"Autopilot","regex":"(?:autopilot).{0,40}\\b([0-9a-f]{32})\\b","confidence":"high"}
+{"name":"Avazapersonalaccesstoken","regex":"(?:avaza).{0,40}\\b([0-9]+-[0-9a-f]{40})\\b","confidence":"high"}
+{"name":"Aviationstack","regex":"(?:aviationstack).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Aws1","regex":"\\b((?:AKIA|ABIA|ACCA|ASIA)[0-9A-Z]{16})\\b","confidence":"high"}
+{"name":"AwsAccess","regex":"aws[_-]?access(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwsAccessKey","regex":"aws[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwsAccessKeyId1","regex":"aws[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwsAccessKeyIdValue","regex":"(A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}","confidence":"high"}
+{"name":"AwsApiGateway","regex":"[0-9a-z]+.execute-api.[0-9a-z._-]+.amazonaws.com","confidence":"low"}
+{"name":"AwsApiKey","regex":"AKIA[0-9A-Z]{16}","confidence":"high"}
+{"name":"AwsAppsyncGraphqlKey","regex":"da2-[a-z0-9]{26}","confidence":"high"}
+{"name":"AwsArn","regex":"arn:aws:[a-z0-9-]+:[a-z]{2}-[a-z]+-[0-9]+:[0-9]+:.+","confidence":"high"}
+{"name":"AwsClientId","regex":"(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}","confidence":"low"}
+{"name":"AwsConfigAccesskeyid","regex":"aws[_-]?config[_-]?accesskeyid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwsConfigSecretaccesskey","regex":"aws[_-]?config[_-]?secretaccesskey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwsCredFileInfo","regex":"(aws_access_key_id|aws_secret_access_key)","confidence":"high"}
+{"name":"AwsEc2External","regex":"ec2-[0-9a-z._-]+.compute(-1)?.amazonaws.com","confidence":"low"}
+{"name":"AwsEc2Internal","regex":"[0-9a-z._-]+.compute(-1)?.internal","confidence":"low"}
+{"name":"AwsElasticcache","regex":"[0-9a-z._-]+.cache.amazonaws.com","confidence":"low"}
+{"name":"AwsElb","regex":"[0-9a-z._-]+.elb.amazonaws.com","confidence":"low"}
+{"name":"AwsKey","regex":"aws[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwsMwsId","regex":"mzn\\.mws\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}","confidence":"low"}
+{"name":"AwsMwsKey","regex":"amzn\\.mws\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}","confidence":"high"}
+{"name":"AwsPatterns","regex":"(?:accesskeyid|secretaccesskey|aws_access_key_id|aws_secret_access_key)","confidence":"low"}
+{"name":"AwsRds","regex":"[0-9a-z._-]+.rds.amazonaws.com","confidence":"high"}
+{"name":"AwsS3Bucket","regex":"s3:\/\/[0-9a-z._\/-]+","confidence":"high"}
+{"name":"AwsSecret","regex":"aws[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwsSecretAccessKey","regex":"aws[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwsSecretKey","regex":"aws[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwsSecrets","regex":"aws[_-]?secrets(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwsSesAccessKeyId","regex":"aws[_-]?ses[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwsSesSecretAccessKey","regex":"aws[_-]?ses[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Awsaccesskeyid","regex":"awsaccesskeyid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwscnAccessKeyId","regex":"awscn[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"AwscnSecretAccessKey","regex":"awscn[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Awssecretkey","regex":"awssecretkey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Axonaut","regex":"(?:axonaut).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Aylien1","regex":"(?:aylien).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Aylien2","regex":"(?:aylien).{0,40}\\b([a-z0-9]{8})\\b","confidence":"high"}
+{"name":"Ayrshare","regex":"(?:ayrshare).{0,40}\\b([A-Z]{7}-[A-Z0-9]{7}-[A-Z0-9]{7}-[A-Z0-9]{7})\\b","confidence":"high"}
+{"name":"B2AppKey","regex":"b2[_-]?app[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"B2Bucket","regex":"b2[_-]?bucket(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Bannerbear","regex":"(?:bannerbear).{0,40}\\b([0-9a-zA-Z]{22}tt)\\b","confidence":"high"}
+{"name":"Baremetrics","regex":"(?:baremetrics).{0,40}\\b([a-zA-Z0-9_]{25})\\b","confidence":"high"}
+{"name":"Baseapiio","regex":"(?:baseapi|base-api).{0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b","confidence":"high"}
+{"name":"Beamer","regex":"(?:beamer).{0,40}\\b([a-zA-Z0-9_+\/]{45}=)","confidence":"high"}
+{"name":"BearerToken","regex":"(bearer).+","confidence":"low"}
+{"name":"Beebole","regex":"(?:beebole).{0,40}\\b([0-9a-z]{40})\\b","confidence":"high"}
+{"name":"Besttime","regex":"(?:besttime).{0,40}\\b([0-9A-Za-z_]{36})\\b","confidence":"high"}
+{"name":"Billomat1","regex":"(?:billomat).{0,40}\\b([0-9a-z]{1,})\\b","confidence":"high"}
+{"name":"Billomat2","regex":"(?:billomat).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"BintrayApiKey","regex":"bintray[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BintrayApikey","regex":"bintray[_-]?apikey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BintrayGpgPassword","regex":"bintray[_-]?gpg[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BintrayKey","regex":"bintray[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BintrayToken","regex":"bintray[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Bintraykey","regex":"bintraykey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Bitbar","regex":"(?:bitbar).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Bitcoinaverage","regex":"(?:bitcoinaverage).{0,40}\\b([a-zA-Z0-9]{43})\\b","confidence":"high"}
+{"name":"Bitfinex","regex":"(?:bitfinex).{0,40}\\b([A-Za-z0-9_-]{43})\\b","confidence":"high"}
+{"name":"BitlySecretKey","regex":"R_[0-9a-f]{32}","confidence":"high"}
+{"name":"Bitlyaccesstoken","regex":"(?:bitly).{0,40}\\b([a-zA-Z-0-9]{40})\\b","confidence":"high"}
+{"name":"Bitmex1","regex":"(?:bitmex).{0,40}([ \\r\\n]{1}[0-9a-zA-Z\\-\\_]{24}[ \\r\\n]{1})","confidence":"high"}
+{"name":"Bitmex2","regex":"(?:bitmex).{0,40}([ \\r\\n]{1}[0-9a-zA-Z\\-\\_]{48}[ \\r\\n]{1})","confidence":"high"}
+{"name":"Blablabus","regex":"(?:blablabus).{0,40}\\b([0-9A-Za-z]{22})\\b","confidence":"high"}
+{"name":"Blazemeter","regex":"(?:blazemeter|runscope).{0,40}\\b([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b","confidence":"high"}
+{"name":"Blitapp","regex":"(?:blitapp).{0,40}\\b([a-zA-Z0-9_-]{39})\\b","confidence":"high"}
+{"name":"Blogger","regex":"(?:blogger).{0,40}\\b([0-9A-Za-z-]{39})\\b","confidence":"low"}
+{"name":"BluemixApiKey","regex":"bluemix[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BluemixAuth","regex":"bluemix[_-]?auth(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BluemixPass","regex":"bluemix[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BluemixPassProd","regex":"bluemix[_-]?pass[_-]?prod(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BluemixPassword","regex":"bluemix[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BluemixPwd","regex":"bluemix[_-]?pwd(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BluemixUsername","regex":"bluemix[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Bombbomb","regex":"(?:bombbomb).{0,40}\\b([a-zA-Z0-9-._]{704})\\b","confidence":"high"}
+{"name":"Boostnote","regex":"(?:boostnote).{0,40}\\b([0-9a-f]{64})\\b","confidence":"high"}
+{"name":"Borgbase","regex":"(?:borgbase).{0,40}\\b([a-zA-Z0-9\/_.-]{148,152})\\b","confidence":"high"}
+{"name":"BracketsRepoOauthToken","regex":"brackets[_-]?repo[_-]?oauth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Brandfetch","regex":"(?:brandfetch).{0,40}\\b([0-9A-Za-z]{40})\\b","confidence":"high"}
+{"name":"BrowserStackAccessKey","regex":"browser[_-]?stack[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BrowserstackAccessKey","regex":"browserstack[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Browshot","regex":"(?:browshot).{0,40}\\b([a-zA-Z-0-9]{28})\\b","confidence":"high"}
+{"name":"BucketeerAwsAccessKeyId","regex":"bucketeer[_-]?aws[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BucketeerAwsSecretAccessKey","regex":"bucketeer[_-]?aws[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Buddyns","regex":"(?:buddyns).{0,40}\\b([0-9a-z]{40})\\b","confidence":"high"}
+{"name":"Bugherd","regex":"(?:bugherd).{0,40}\\b([0-9a-z]{22})\\b","confidence":"high"}
+{"name":"Bugsnag","regex":"(?:bugsnag).{0,40}\\b([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b","confidence":"high"}
+{"name":"Buildkite","regex":"(?:buildkite).{0,40}\\b([a-z0-9]{40})\\b","confidence":"high"}
+{"name":"BuiltBranchDeployKey","regex":"built[_-]?branch[_-]?deploy[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Bulbul","regex":"(?:bulbul).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"BundlesizeGithubToken","regex":"bundlesize[_-]?github[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Buttercms","regex":"(?:buttercms).{0,40}\\b([a-z0-9]{40})\\b","confidence":"high"}
+{"name":"BxPassword","regex":"bx[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"BxUsername","regex":"bx[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CacheS3SecretKey","regex":"cache[_-]?s3[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Caflou","regex":"(?:caflou).{0,40}\\b([a-bA-Z0-9\\S]{155})\\b","confidence":"high"}
+{"name":"Calendarific","regex":"(?:calendarific).{0,40}\\b([a-z0-9]{40})\\b","confidence":"high"}
+{"name":"Calendlyapikey","regex":"(?:calendly).{0,40}\\b([a-zA-Z-0-9]{20}.[a-zA-Z-0-9]{171}.[a-zA-Z-0-9_]{43})\\b","confidence":"high"}
+{"name":"Calorieninja","regex":"(?:calorieninja).{0,40}\\b([0-9A-Za-z]{40})\\b","confidence":"high"}
+{"name":"Campayn","regex":"(?:campayn).{0,40}\\b([a-z0-9]{64})\\b","confidence":"high"}
+{"name":"Cannyio","regex":"(?:canny).{0,40}\\b([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[0-9]{4}-[a-z0-9]{12})\\b","confidence":"high"}
+{"name":"Capsulecrm","regex":"(?:capsulecrm).{0,40}\\b([a-zA-Z0-9-._+=]{64})\\b","confidence":"high"}
+{"name":"Captaindata1","regex":"(?:captaindata).{0,40}\\b([0-9a-f]{8}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{12})\\b","confidence":"high"}
+{"name":"Captaindata2","regex":"(?:captaindata).{0,40}\\b([0-9a-f]{64})\\b","confidence":"high"}
+{"name":"Carboninterface","regex":"(?:carboninterface).{0,40}\\b([a-zA-Z0-9]{21})\\b","confidence":"high"}
+{"name":"CargoToken","regex":"cargo[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Cashboard1","regex":"(?:cashboard).{0,40}\\b([0-9A-Z]{3}-[0-9A-Z]{3}-[0-9A-Z]{3}-[0-9A-Z]{3})\\b","confidence":"high"}
+{"name":"Cashboard2","regex":"(?:cashboard).{0,40}\\b([0-9a-z]{1,})\\b","confidence":"high"}
+{"name":"Caspio1","regex":"(?:caspio).{0,40}\\b([a-z0-9]{8})\\b","confidence":"high"}
+{"name":"Caspio2","regex":"(?:caspio).{0,40}\\b([a-z0-9]{50})\\b","confidence":"high"}
+{"name":"CattleAccessKey","regex":"cattle[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CattleAgentInstanceAuth","regex":"cattle[_-]?agent[_-]?instance[_-]?auth(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CattleSecretKey","regex":"cattle[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Censys1","regex":"(?:censys).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Censys2","regex":"(?:censys).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"CensysSecret","regex":"censys[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Centralstationcrm","regex":"(?:centralstation).{0,40}\\b([a-z0-9]{30})\\b","confidence":"high"}
+{"name":"CertificatePassword","regex":"certificate[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Cexio1","regex":"(?:cexio|cex.io).{0,40}\\b([a-z]{2}[0-9]{9})\\b","confidence":"high"}
+{"name":"Cexio2","regex":"(?:cexio|cex.io).{0,40}\\b([0-9A-Za-z]{24,27})\\b","confidence":"high"}
+{"name":"CfPassword","regex":"cf[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Chatbot","regex":"(?:chatbot).{0,40}\\b([a-zA-Z0-9_]{32})\\b","confidence":"high"}
+{"name":"Chatfule","regex":"(?:chatfuel).{0,40}\\b([a-zA-Z0-9]{128})\\b","confidence":"high"}
+{"name":"Checio","regex":"(?:checio).{0,40}\\b(pk_[a-z0-9]{45})\\b","confidence":"high"}
+{"name":"Checklyhq","regex":"(?:checklyhq).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Checkout1","regex":"(?:checkout).{0,40}\\b((sk_|sk_test_)[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\\b","confidence":"high"}
+{"name":"Checkout2","regex":"(?:checkout).{0,40}\\b(cus_[0-9a-zA-Z]{26})\\b","confidence":"high"}
+{"name":"Checkvist1","regex":"(?:checkvist).{0,40}\\b([\\w\\.-]+@[\\w-]+\\.[\\w\\.-]{2,5})\\b","confidence":"high"}
+{"name":"Checkvist2","regex":"(?:checkvist).{0,40}\\b([0-9a-zA-Z]{14})\\b","confidence":"high"}
+{"name":"ChevernyToken","regex":"cheverny[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ChromeClientSecret","regex":"chrome[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"ChromeRefreshToken","regex":"chrome[_-]?refresh[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"CiDeployPassword","regex":"ci[_-]?deploy[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"CiProjectUrl","regex":"ci[_-]?project[_-]?url(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"CiRegistryUser","regex":"ci[_-]?registry[_-]?user(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"CiServerName","regex":"ci[_-]?server[_-]?name(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"CiUserToken","regex":"ci[_-]?user[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Cicero","regex":"(?:cicero).{0,40}\\b([0-9a-z]{40})\\b","confidence":"high"}
+{"name":"Circleci","regex":"(?:circle).{0,40}([a-fA-F0-9]{40})","confidence":"low"}
+{"name":"ClaimrDatabase","regex":"claimr[_-]?database(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ClaimrDb","regex":"claimr[_-]?db(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ClaimrSuperuser","regex":"claimr[_-]?superuser(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ClaimrToken","regex":"claimr[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Clearbit","regex":"(?:clearbit).{0,40}\\b([0-9a-z_]{35})\\b","confidence":"high"}
+{"name":"CliE2ECmaToken","regex":"cli[_-]?e2e[_-]?cma[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Clickhelp1","regex":"\\b([0-9A-Za-z]{3,20}.try.clickhelp.co)\\b","confidence":"high"}
+{"name":"Clickhelp2","regex":"(?:clickhelp).{0,40}\\b([0-9A-Za-z]{24})\\b","confidence":"high"}
+{"name":"Clicksendsms2","regex":"(?:sms).{0,40}\\b([a-zA-Z0-9]{3,20}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,5})\\b","confidence":"high"}
+{"name":"Clickuppersonaltoken","regex":"(?:clickup).{0,40}\\b(pk_[0-9]{8}_[0-9A-Z]{32})\\b","confidence":"high"}
+{"name":"Cliengo","regex":"(?:cliengo).{0,40}\\b([0-9a-f]{8}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{12})\\b","confidence":"high"}
+{"name":"ClientSecret","regex":"client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Clinchpad","regex":"(?:clinchpad).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Clockify","regex":"(?:clockify).{0,40}\\b([a-zA-Z0-9]{48})\\b","confidence":"high"}
+{"name":"Clockworksms1","regex":"(?:clockwork|textanywhere).{0,40}\\b([0-9a-zA-Z]{24})\\b","confidence":"high"}
+{"name":"Clockworksms2","regex":"(?:clockwork|textanywhere).{0,40}\\b([0-9]{5})\\b","confidence":"high"}
+{"name":"ClojarsPassword","regex":"clojars[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Closecrm","regex":"\\b(api_[a-z0-9A-Z.]{45})\\b","confidence":"high"}
+{"name":"CloudApiKey","regex":"cloud[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"CloudantArchivedDatabase","regex":"cloudant[_-]?archived[_-]?database(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CloudantAuditedDatabase","regex":"cloudant[_-]?audited[_-]?database(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CloudantDatabase","regex":"cloudant[_-]?database(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CloudantInstance","regex":"cloudant[_-]?instance(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CloudantOrderDatabase","regex":"cloudant[_-]?order[_-]?database(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CloudantParsedDatabase","regex":"cloudant[_-]?parsed[_-]?database(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CloudantPassword","regex":"cloudant[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CloudantProcessedDatabase","regex":"cloudant[_-]?processed[_-]?database(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CloudantServiceDatabase","regex":"cloudant[_-]?service[_-]?database(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Cloudelements1","regex":"(?:cloudelements).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Cloudelements2","regex":"(?:cloudelements).{0,40}\\b([a-zA-Z0-9]{43})\\b","confidence":"high"}
+{"name":"CloudflareApiKey","regex":"cloudflare[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"CloudflareAuthEmail","regex":"cloudflare[_-]?auth[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"CloudflareAuthKey","regex":"cloudflare[_-]?auth[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CloudflareEmail","regex":"cloudflare[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Cloudflareapitoken","regex":"(?:cloudflare).{0,40}\\b([A-Za-z0-9_-]{40})\\b","confidence":"low"}
+{"name":"Cloudflarecakey","regex":"(?:cloudflare).{0,40}\\b(v[A-Za-z0-9._-]{173,})\\b","confidence":"high"}
+{"name":"Cloudimage","regex":"(?:cloudimage).{0,40}\\b([a-z0-9_]{30})\\b","confidence":"high"}
+{"name":"CloudinaryCredentials","regex":"cloudinary:\/\/[0-9]+:[A-Za-z0-9\\-_\\.]+@[A-Za-z0-9\\-_\\.]+","confidence":"high"}
+{"name":"CloudinaryUrl","regex":"cloudinary[_-]?url(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CloudinaryUrlStaging","regex":"cloudinary[_-]?url[_-]?staging(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Cloudmersive","regex":"(?:cloudmersive).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"Cloudplan","regex":"(?:cloudplan).{0,40}\\b([A-Z0-9-]{32})\\b","confidence":"high"}
+{"name":"Cloverly","regex":"(?:cloverly).{0,40}\\b([a-z0-9:_]{28})\\b","confidence":"high"}
+{"name":"Cloze1","regex":"(?:cloze).{0,40}\\b([0-9a-f]{32})\\b","confidence":"high"}
+{"name":"Cloze2","regex":"(?:cloze).{0,40}\\b([\\w\\.-]+@[\\w-]+\\.[\\w\\.-]{2,5})\\b","confidence":"high"}
+{"name":"CluRepoUrl","regex":"clu[_-]?repo[_-]?url(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CluSshPrivateKeyBase64","regex":"clu[_-]?ssh[_-]?private[_-]?key[_-]?base64(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Clustdoc","regex":"(?:clustdoc).{0,40}\\b([0-9a-zA-Z]{60})\\b","confidence":"high"}
+{"name":"CnAccessKeyId","regex":"cn[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CnSecretAccessKey","regex":"cn[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CocoapodsTrunkEmail","regex":"cocoapods[_-]?trunk[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CocoapodsTrunkToken","regex":"cocoapods[_-]?trunk[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Codacy","regex":"(?:codacy).{0,40}\\b([0-9A-Za-z]{20})\\b","confidence":"high"}
+{"name":"CodacyProjectToken","regex":"codacy[_-]?project[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Codeclimate","regex":"(codeclima.{0,50}(\"|')?[0-9a-f]{64}(\"|')?)","confidence":"low"}
+{"name":"CodeclimateRepoToken","regex":"codeclimate[_-]?repo[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CodecovToken","regex":"codecov[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CodingToken","regex":"coding[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Coinapi","regex":"(?:coinapi).{0,40}\\b([A-Z0-9-]{36})\\b","confidence":"high"}
+{"name":"Coinbase","regex":"(?:coinbase).{0,40}\\b([a-zA-Z-0-9]{64})\\b","confidence":"high"}
+{"name":"Coinlayer","regex":"(?:coinlayer).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Coinlib","regex":"(?:coinlib).{0,40}\\b([a-z0-9]{16})\\b","confidence":"high"}
+{"name":"Column","regex":"(?:column).{0,40}\\b((?:test|live)_[a-zA-Z0-9]{27})\\b","confidence":"high"}
+{"name":"Commercejs","regex":"(?:commercejs).{0,40}\\b([a-z0-9_]{48})\\b","confidence":"high"}
+{"name":"Commodities","regex":"(?:commodities).{0,40}\\b([a-zA-Z0-9]{60})\\b","confidence":"high"}
+{"name":"Companyhub1","regex":"(?:companyhub).{0,40}\\b([0-9a-zA-Z]{20})\\b","confidence":"high"}
+{"name":"Companyhub2","regex":"(?:companyhub).{0,40}\\b([a-zA-Z0-9$%^=-]{4,32})\\b","confidence":"high"}
+{"name":"ConektaApikey","regex":"conekta[_-]?apikey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Confluent1","regex":"(?:confluent).{0,40}\\b([a-zA-Z-0-9]{16})\\b","confidence":"high"}
+{"name":"Confluent2","regex":"(?:confluent).{0,40}\\b([a-zA-Z-0-9]{64})\\b","confidence":"high"}
+{"name":"ConsumerKey","regex":"consumer[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Consumerkey","regex":"consumerkey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ContentfulAccessToken","regex":"contentful[_-]?access[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ContentfulCmaTestToken","regex":"contentful[_-]?cma[_-]?test[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ContentfulIntegrationManagementToken","regex":"contentful[_-]?integration[_-]?management[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ContentfulPhpManagementTestToken","regex":"contentful[_-]?php[_-]?management[_-]?test[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ContentfulTestOrgCmaToken","regex":"contentful[_-]?test[_-]?org[_-]?cma[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ContentfulV2AccessToken","regex":"contentful[_-]?v2[_-]?access[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ConversationPassword","regex":"conversation[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ConversationUsername","regex":"conversation[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Convertkit","regex":"(?:convertkit).{0,40}\\b([a-z0-9A-Z_]{22})\\b","confidence":"high"}
+{"name":"Convier","regex":"(?:convier).{0,40}\\b([0-9]{2}\\|[a-zA-Z0-9]{40})\\b","confidence":"high"}
+{"name":"Copper2","regex":"(?:copper).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"CosSecrets","regex":"cos[_-]?secrets(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Countrylayer","regex":"(?:countrylayer).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Courier","regex":"(?:courier).{0,40}\\b(pk\\_[a-zA-Z0-9]{1,}\\_[a-zA-Z0-9]{28})\\b","confidence":"high"}
+{"name":"Coveralls","regex":"(?:coveralls).{0,40}\\b([a-zA-Z0-9-]{37})\\b","confidence":"high"}
+{"name":"CoverallsApiToken","regex":"coveralls[_-]?api[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CoverallsRepoToken","regex":"coveralls[_-]?repo[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CoverallsToken","regex":"coveralls[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"CoverityScanToken","regex":"coverity[_-]?scan[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Crowdin","regex":"(?:crowdin).{0,40}\\b([0-9A-Za-z]{80})\\b","confidence":"high"}
+{"name":"Cryptocompare","regex":"(?:cryptocompare).{0,40}\\b([a-z-0-9]{64})\\b","confidence":"high"}
+{"name":"Currencycloud1","regex":"(?:currencycloud).{0,40}\\b([0-9a-z]{64})\\b","confidence":"high"}
+{"name":"Currencyfreaks","regex":"(?:currencyfreaks).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Currencylayer","regex":"(?:currencylayer).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Currencyscoop","regex":"(?:currencyscoop).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Currentsapi","regex":"(?:currentsapi).{0,40}\\b([a-zA-Z0-9\\S]{48})\\b","confidence":"high"}
+{"name":"Customerguru1","regex":"(?:guru).{0,40}\\b([a-z0-9A-Z]{50})\\b","confidence":"high"}
+{"name":"Customerguru2","regex":"(?:guru).{0,40}\\b([a-z0-9A-Z]{30})\\b","confidence":"high"}
+{"name":"Customerio","regex":"(?:customer).{0,40}\\b([a-z0-9A-Z]{20})\\b","confidence":"low"}
+{"name":"CypressRecordKey","regex":"cypress[_-]?record[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"D7Network","regex":"(?:d7network).{0,40}\\b([a-zA-Z0-9\\W\\S]{23}\\=)","confidence":"high"}
+{"name":"Dailyco","regex":"(?:daily).{0,40}\\b([0-9a-f]{64})\\b","confidence":"high"}
+{"name":"Dandelion","regex":"(?:dandelion).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"DangerGithubApiToken","regex":"danger[_-]?github[_-]?api[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DatabaseHost","regex":"database[_-]?host(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DatabaseName","regex":"database[_-]?name(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DatabasePassword","regex":"database[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DatabasePort","regex":"database[_-]?port(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DatabaseUser","regex":"database[_-]?user(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DatabaseUsername","regex":"database[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Databricks","regex":"dapi[a-f0-9]{32}\\b","confidence":"high"}
+{"name":"DatadogApiKey","regex":"datadog[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DatadogAppKey","regex":"datadog[_-]?app[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Datadogtoken1","regex":"(?:datadog).{0,40}\\b([a-zA-Z-0-9]{32})\\b","confidence":"low"}
+{"name":"Datadogtoken2","regex":"(?:datadog).{0,40}\\b([a-zA-Z-0-9]{40})\\b","confidence":"low"}
+{"name":"Datafire","regex":"(?:datafire).{0,40}\\b([a-z0-9\\S]{175,190})\\b","confidence":"high"}
+{"name":"Datagov","regex":"(?:data.gov).{0,40}\\b([a-zA-Z0-9]{40})\\b","confidence":"high"}
+{"name":"DbConnection","regex":"db[_-]?connection(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DbDatabase","regex":"db[_-]?database(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DbHost","regex":"db[_-]?host(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DbPassword","regex":"db[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"DbPw","regex":"db[_-]?pw(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"DbUser","regex":"db[_-]?user(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DbUsername","regex":"db[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DdgTestEmail","regex":"ddg[_-]?test[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DdgTestEmailPw","regex":"ddg[_-]?test[_-]?email[_-]?pw(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DdgcGithubToken","regex":"ddgc[_-]?github[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Debounce","regex":"(?:debounce).{0,40}\\b([a-zA-Z0-9]{13})\\b","confidence":"low"}
+{"name":"Deepai","regex":"(?:deepai).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"Deepgram","regex":"(?:deepgram).{0,40}\\b([0-9a-z]{40})\\b","confidence":"high"}
+{"name":"Delighted","regex":"(?:delighted).{0,40}\\b([a-z0-9A-Z]{32})\\b","confidence":"high"}
+{"name":"DeployPassword","regex":"deploy[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DeploySecure","regex":"deploy[_-]?secure(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DeployToken","regex":"deploy[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DeployUser","regex":"deploy[_-]?user(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Deputy1","regex":"\\b([0-9a-z]{1,}.as.deputy.com)\\b","confidence":"high"}
+{"name":"Deputy2","regex":"(?:deputy).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Detectlanguage","regex":"(?:detectlanguage).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Dfuse","regex":"\\b(web\\_[0-9a-z]{32})\\b","confidence":"high"}
+{"name":"DgpgPassphrase","regex":"dgpg[_-]?passphrase(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Diffbot","regex":"(?:diffbot).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"DigitaloceanAccessToken","regex":"digitalocean[_-]?access[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DigitaloceanSshKeyBody","regex":"digitalocean[_-]?ssh[_-]?key[_-]?body(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DigitaloceanSshKeyIds","regex":"digitalocean[_-]?ssh[_-]?key[_-]?ids(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Digitaloceantoken","regex":"(?:digitalocean).{0,40}\\b([A-Za-z0-9_-]{64})\\b","confidence":"high"}
+{"name":"DiscordWebhook","regex":"https:\/\/discordapp\\.com\/api\/webhooks\/[0-9]+\/[A-Za-z0-9\\-]+","confidence":"high"}
+{"name":"Discordbottoken1","regex":"(?:discord).{0,40}\\b([A-Za-z0-9_-]{24}\\.[A-Za-z0-9_-]{6}\\.[A-Za-z0-9_-]{27})\\b","confidence":"high"}
+{"name":"Discordbottoken2","regex":"(?:discord).{0,40}\\b([0-9]{17})\\b","confidence":"high"}
+{"name":"Discordwebhook","regex":"(https:\\\/\\\/discord.com\\\/api\\\/webhooks\\\/[0-9]{18}\\\/[0-9a-zA-Z-]{68})","confidence":"high"}
+{"name":"Ditto","regex":"(?:ditto).{0,40}\\b([a-z0-9]{8}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{12}\\.[a-z0-9]{40})\\b","confidence":"high"}
+{"name":"Dnscheck1","regex":"(?:dnscheck).{0,40}\\b([a-z0-9A-Z-]{36})\\b","confidence":"high"}
+{"name":"Dnscheck2","regex":"(?:dnscheck).{0,40}\\b([a-z0-9A-Z]{32})\\b","confidence":"high"}
+{"name":"DockerHubPassword","regex":"docker[_-]?hub[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"DockerKey","regex":"docker[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DockerPass","regex":"docker[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DockerPasswd","regex":"docker[_-]?passwd(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"DockerPassword","regex":"docker[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"DockerPostgresUrl","regex":"docker[_-]?postgres[_-]?url(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DockerToken","regex":"docker[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"DockerhubPassword","regex":"dockerhub[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Dockerhubpassword","regex":"dockerhubpassword(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Documo","regex":"\\b(ey[a-zA-Z0-9]{34}.ey[a-zA-Z0-9]{154}.[a-zA-Z0-9_-]{43})\\b","confidence":"high"}
+{"name":"DoordashAuthToken","regex":"doordash[_-]?auth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Doppler","regex":"\\b(dp\\.pt\\.[a-zA-Z0-9]{43})\\b","confidence":"high"}
+{"name":"Dotmailer1","regex":"(?:dotmailer).{0,40}\\b(apiuser-[a-z0-9]{12}@apiconnector.com)\\b","confidence":"high"}
+{"name":"Dotmailer2","regex":"(?:dotmailer).{0,40}\\b([a-zA-Z0-9\\S]{8,24})\\b","confidence":"high"}
+{"name":"Dovico","regex":"(?:dovico).{0,40}\\b([0-9a-z]{32}\\.[0-9a-z]{1,}\\b)","confidence":"high"}
+{"name":"Dronahq","regex":"(?:dronahq).{0,40}\\b([a-z0-9]{50})\\b","confidence":"high"}
+{"name":"Droneci","regex":"(?:droneci).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Dropbox","regex":"\\b(sl\\.[A-Za-z0-9\\-\\_]{130,140})\\b","confidence":"high"}
+{"name":"DropboxOauthBearer","regex":"dropbox[_-]?oauth[_-]?bearer(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"DropletTravisPassword","regex":"droplet[_-]?travis[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"DsonarLogin","regex":"dsonar[_-]?login(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"DsonarProjectkey","regex":"dsonar[_-]?projectkey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Dwolla","regex":"(?:dwolla).{0,40}\\b([a-zA-Z-0-9]{50})\\b","confidence":"high"}
+{"name":"Dynalist","regex":"(?:dynalist).{0,40}\\b([a-zA-Z0-9-_]{128})\\b","confidence":"high"}
+{"name":"DynatraceToken","regex":"dt0[a-zA-Z]{1}[0-9]{2}\\.[A-Z0-9]{24}\\.[A-Z0-9]{64}","confidence":"high"}
+{"name":"Dyspatch","regex":"(?:dyspatch).{0,40}\\b([A-Z0-9]{52})\\b","confidence":"high"}
+{"name":"Eagleeyenetworks1","regex":"(?:eagleeyenetworks).{0,40}\\b([a-zA-Z0-9]{3,20}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,5})\\b","confidence":"high"}
+{"name":"Eagleeyenetworks2","regex":"(?:eagleeyenetworks).{0,40}\\b([a-zA-Z0-9]{15})\\b","confidence":"high"}
+{"name":"Easyinsight1","regex":"(?:easyinsight|easy-insight).{0,40}\\b([a-zA-Z0-9]{20})\\b","confidence":"high"}
+{"name":"Easyinsight2","regex":"(?:easyinsight|easy-insight).{0,40}\\b([0-9Aa-zA-Z]{20})\\b","confidence":"high"}
+{"name":"Ec","regex":"-----BEGIN EC PRIVATE KEY-----","confidence":"high"}
+{"name":"Edamam1","regex":"(?:edamam).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Edamam2","regex":"(?:edamam).{0,40}\\b([0-9a-z]{8})\\b","confidence":"high"}
+{"name":"Edenai","regex":"(?:edenai).{0,40}\\b([a-zA-Z0-9]{36}.[a-zA-Z0-9]{92}.[a-zA-Z0-9_]{43})\\b","confidence":"high"}
+{"name":"Eightxeight1","regex":"(?:8x8).{0,40}\\b([a-zA-Z0-9_]{18,30})\\b","confidence":"low"}
+{"name":"Eightxeight2","regex":"(?:8x8).{0,40}\\b([a-zA-Z0-9]{43})\\b","confidence":"high"}
+{"name":"ElasticCloudAuth","regex":"elastic[_-]?cloud[_-]?auth(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Elasticemail","regex":"(?:elastic).{0,40}\\b([A-Za-z0-9_-]{96})\\b","confidence":"high"}
+{"name":"ElasticsearchPassword","regex":"elasticsearch[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Enablex1","regex":"(?:enablex).{0,40}\\b([a-zA-Z0-9]{36})\\b","confidence":"high"}
+{"name":"Enablex2","regex":"(?:enablex).{0,40}\\b([a-z0-9]{24})\\b","confidence":"high"}
+{"name":"EncryptionPassword","regex":"encryption[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"EndUserPassword","regex":"end[_-]?user[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Enigma","regex":"(?:enigma).{0,40}\\b([a-zA-Z0-9]{40})\\b","confidence":"high"}
+{"name":"EnvGithubOauthToken","regex":"env[_-]?github[_-]?oauth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"EnvHerokuApiKey","regex":"env[_-]?heroku[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"EnvKey","regex":"env[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"EnvSecret","regex":"env[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"EnvSecretAccessKey","regex":"env[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"EnvSonatypePassword","regex":"env[_-]?sonatype[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Ethplorer","regex":"(?:ethplorer).{0,40}\\b([a-z0-9A-Z-]{22})\\b","confidence":"high"}
+{"name":"Etsyapikey","regex":"(?:etsy).{0,40}\\b([a-zA-Z-0-9]{24})\\b","confidence":"low"}
+{"name":"EurekaAwssecretkey","regex":"eureka[_-]?awssecretkey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Everhour","regex":"(?:everhour).{0,40}\\b([0-9Aa-f]{4}-[0-9a-f]{4}-[0-9a-f]{6}-[0-9a-f]{6}-[0-9a-f]{8})\\b","confidence":"high"}
+{"name":"Exchangerateapi","regex":"(?:exchangerate).{0,40}\\b([a-z0-9]{24})\\b","confidence":"high"}
+{"name":"Exchangeratesapi","regex":"(?:exchangerates).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"ExpPassword","regex":"exp[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"FacebookAccessToken","regex":"EAACEdEose0cBA[0-9A-Za-z]+","confidence":"high"}
+{"name":"FacebookOauth","regex":"[fF][aA][cC][eE][bB][oO][oO][kK].*['|\"][0-9a-f]{32}['|\"]","confidence":"low"}
+{"name":"Facebookoauth","regex":"(?:facebook).{0,40}\\b([A-Za-z0-9]{32})\\b","confidence":"low"}
+{"name":"Faceplusplus","regex":"(?:faceplusplus).{0,40}\\b([0-9a-zA-Z_-]{32})\\b","confidence":"high"}
+{"name":"Fakejson","regex":"(?:fakejson).{0,40}\\b([a-zA-Z0-9]{22})\\b","confidence":"high"}
+{"name":"Fastforex","regex":"(?:fastforex).{0,40}\\b([a-z0-9-]{28})\\b","confidence":"high"}
+{"name":"Fastlypersonaltoken","regex":"(?:fastly).{0,40}\\b([A-Za-z0-9_-]{32})\\b","confidence":"high"}
+{"name":"FcmServerKey","regex":"AAAA[a-zA-Z0-9_-]{7}:[a-zA-Z0-9_-]{140}","confidence":"low"}
+{"name":"Feedier","regex":"(?:feedier).{0,40}\\b([a-z0-9A-Z]{32})\\b","confidence":"high"}
+{"name":"Fetchrss","regex":"(?:fetchrss).{0,40}\\b([0-9A-Za-z.]{40})\\b","confidence":"high"}
+{"name":"Figmapersonalaccesstoken","regex":"(?:figma).{0,40}\\b([0-9]{6}-[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b","confidence":"high"}
+{"name":"FilePassword","regex":"file[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Fileio","regex":"(?:fileio).{0,40}\\b([A-Z0-9.-]{39})\\b","confidence":"high"}
+{"name":"Finage","regex":"\\b(API_KEY[0-9A-Z]{32})\\b","confidence":"high"}
+{"name":"Financialmodelingprep","regex":"(?:financialmodelingprep).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Findl","regex":"(?:findl).{0,40}\\b([a-z0-9]{8}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{12})\\b","confidence":"high"}
+{"name":"Finnhub","regex":"(?:finnhub).{0,40}\\b([0-9a-z]{20})\\b","confidence":"high"}
+{"name":"FirebaseApiJson","regex":"firebase[_-]?api[_-]?json(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"FirebaseApiToken","regex":"firebase[_-]?api[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"FirebaseDatabaseDetect1","regex":"[a-z0-9.-]+\\.firebaseio\\.com","confidence":"low"}
+{"name":"FirebaseDatabaseDetect2","regex":"[a-z0-9.-]+\\.firebaseapp\\.com","confidence":"low"}
+{"name":"FirebaseKey","regex":"firebase[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"FirebaseProjectDevelop","regex":"firebase[_-]?project[_-]?develop(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"FirebaseToken","regex":"firebase[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"FirefoxSecret","regex":"firefox[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Fixerio","regex":"(?:fixer).{0,40}\\b([A-Za-z0-9]{32})\\b","confidence":"high"}
+{"name":"FlaskSecretKey","regex":"flask[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Flatio","regex":"(?:flat).{0,40}\\b([0-9a-z]{128})\\b","confidence":"high"}
+{"name":"Fleetbase","regex":"\\b(flb_live_[0-9a-zA-Z]{20})\\b","confidence":"high"}
+{"name":"Flickr","regex":"(?:flickr).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"FlickrApiKey","regex":"flickr[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"FlickrApiSecret","regex":"flickr[_-]?api[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Flightapi","regex":"(?:flightapi).{0,40}\\b([a-z0-9]{24})\\b","confidence":"high"}
+{"name":"Flightstats1","regex":"(?:flightstats).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Flightstats2","regex":"(?:flightstats).{0,40}\\b([0-9a-z]{8})\\b","confidence":"high"}
+{"name":"Float","regex":"(?:float).{0,40}\\b([a-zA-Z0-9-._+=]{59,60})\\b","confidence":"low"}
+{"name":"Flowflu2","regex":"(?:flowflu).{0,40}\\b([a-zA-Z0-9]{51})\\b","confidence":"high"}
+{"name":"Flutterwave","regex":"\\b(FLWSECK-[0-9a-z]{32}-X)\\b","confidence":"high"}
+{"name":"Fmfw1","regex":"(?:fmfw).{0,40}\\b([a-zA-Z0-9-]{32})\\b","confidence":"high"}
+{"name":"Fmfw2","regex":"(?:fmfw).{0,40}\\b([a-zA-Z0-9_-]{32})\\b","confidence":"high"}
+{"name":"Formbucket","regex":"(?:formbucket).{0,40}\\b([0-9A-Za-z]{1,}.[0-9A-Za-z]{1,}\\.[0-9A-Z-a-z\\-_]{1,})","confidence":"high"}
+{"name":"Formio","regex":"(?:formio).{0,40}\\b(eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\\.[0-9A-Za-z]{310}\\.[0-9A-Z-a-z\\-_]{43}[ \\r\\n]{1})","confidence":"high"}
+{"name":"FossaApiKey","regex":"fossa[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Foursquare","regex":"(?:foursquare).{0,40}\\b([0-9A-Z]{48})\\b","confidence":"high"}
+{"name":"Frameio","regex":"\\b(fio-u-[0-9a-zA-Z_-]{64})\\b","confidence":"high"}
+{"name":"Freshbooks1","regex":"(?:freshbooks).{0,40}\\b([0-9a-z]{64})\\b","confidence":"high"}
+{"name":"Freshbooks2","regex":"(?:freshbooks).{0,40}\\b(https:\/\/www.[0-9A-Za-z_-]{1,}.com)\\b","confidence":"high"}
+{"name":"Freshdesk1","regex":"(?:freshdesk).{0,40}\\b([0-9A-Za-z]{20})\\b","confidence":"high"}
+{"name":"Freshdesk2","regex":"\\b([0-9a-z-]{1,}.freshdesk.com)\\b","confidence":"high"}
+{"name":"Front","regex":"(?:front).{0,40}\\b([0-9a-zA-Z]{36}.[0-9a-zA-Z\\.\\-\\_]{188,244})\\b","confidence":"high"}
+{"name":"FtpHost","regex":"ftp[_-]?host(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"FtpLogin","regex":"ftp[_-]?login(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"FtpPassword","regex":"ftp[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"FtpPw","regex":"ftp[_-]?pw(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"FtpUser","regex":"ftp[_-]?user(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"FtpUsername","regex":"ftp[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Fulcrum","regex":"(?:fulcrum).{0,40}\\b([a-z0-9]{80})\\b","confidence":"high"}
+{"name":"Fullstory","regex":"(?:fullstory).{0,40}\\b([a-zA-Z-0-9\/+]{88})\\b","confidence":"high"}
+{"name":"Fusebill","regex":"(?:fusebill).{0,40}\\b([a-zA-Z0-9]{88})\\b","confidence":"high"}
+{"name":"Fxmarket","regex":"(?:fxmarket).{0,40}\\b([0-9Aa-zA-Z-_=]{20})\\b","confidence":"high"}
+{"name":"GcloudBucket","regex":"gcloud[_-]?bucket(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GcloudProject","regex":"gcloud[_-]?project(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GcloudServiceKey","regex":"gcloud[_-]?service[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Gcp","regex":"\\{[^{]+auth_provider_x509_cert_url[^}]+\\}","confidence":"high"}
+{"name":"GcrPassword","regex":"gcr[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GcsBucket","regex":"gcs[_-]?bucket(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Geckoboard","regex":"(?:geckoboard).{0,40}\\b([a-zA-Z0-9]{44})\\b","confidence":"high"}
+{"name":"Generic1376","regex":"jdbc:mysql(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Generic1688","regex":"TOKEN[\\\\-|_|A-Z0-9]*(\\'|\\\")?(:|=)(\\'|\\\")?[\\\\-|_|A-Z0-9]{10}","confidence":"low"}
+{"name":"Generic1689","regex":"API[\\\\-|_|A-Z0-9]*(\\'|\\\")?(:|=)(\\'|\\\")?[\\\\-|_|A-Z0-9]{10}","confidence":"low"}
+{"name":"Generic1691","regex":"SECRET[\\\\-|_|A-Z0-9]*(\\'|\\\")?(:|=)(\\'|\\\")?[\\\\-|_|A-Z0-9]{10}","confidence":"low"}
+{"name":"Generic1692","regex":"AUTHORIZATION[\\\\-|_|A-Z0-9]*(\\'|\\\")?(:|=)(\\'|\\\")?[\\\\-|_|A-Z0-9]{10}","confidence":"low"}
+{"name":"Generic1693","regex":"PASSWORD[\\\\-|_|A-Z0-9]*(\\'|\\\")?(:|=)(\\'|\\\")?[\\\\-|_|A-Z0-9]{10}","confidence":"low"}
+{"name":"Generic1695","regex":"(A|a)(P|p)(Ii)[\\-|_|A-Za-z0-9]*(\\''|\")?( )*(:|=)( )*(\\''|\")?[0-9A-Za-z\\-_]+(\\''|\")?","confidence":"low"}
+{"name":"Generic1700","regex":"BEGIN OPENSSH PRIVATE KEY","confidence":"high"}
+{"name":"Generic1701","regex":"BEGIN PRIVATE KEY","confidence":"high"}
+{"name":"Generic1702","regex":"BEGIN RSA PRIVATE KEY","confidence":"high"}
+{"name":"Generic1703","regex":"BEGIN DSA PRIVATE KEY","confidence":"high"}
+{"name":"Generic1704","regex":"BEGIN EC PRIVATE KEY","confidence":"high"}
+{"name":"Generic1705","regex":"BEGIN PGP PRIVATE KEY BLOCK","confidence":"high"}
+{"name":"Generic1707","regex":"[a-z0-9.-]+\\.s3-[a-z0-9-]\\.amazonaws\\.com","confidence":"low"}
+{"name":"Generic1708","regex":"[a-z0-9.-]+\\.s3-website[.-](eu|ap|us|ca|sa|cn)","confidence":"low"}
+{"name":"Generic1710","regex":"algolia_api_key","confidence":"high"}
+{"name":"Generic1711","regex":"asana_access_token","confidence":"high"}
+{"name":"Generic1713","regex":"azure_tenant","confidence":"high"}
+{"name":"Generic1714","regex":"bitly_access_token","confidence":"high"}
+{"name":"Generic1715","regex":"branchio_secret","confidence":"low"}
+{"name":"Generic1716","regex":"browserstack_access_key","confidence":"high"}
+{"name":"Generic1717","regex":"buildkite_access_token","confidence":"high"}
+{"name":"Generic1718","regex":"comcast_access_token","confidence":"high"}
+{"name":"Generic1719","regex":"datadog_api_key","confidence":"high"}
+{"name":"Generic1720","regex":"deviantart_secret","confidence":"high"}
+{"name":"Generic1721","regex":"deviantart_access_token","confidence":"high"}
+{"name":"Generic1722","regex":"dropbox_api_token","confidence":"high"}
+{"name":"Generic1723","regex":"facebook_appsecret","confidence":"high"}
+{"name":"Generic1724","regex":"facebook_access_token","confidence":"high"}
+{"name":"Generic1725","regex":"firebase_custom_token","confidence":"high"}
+{"name":"Generic1726","regex":"firebase_id_token","confidence":"high"}
+{"name":"Generic1727","regex":"github_client","confidence":"high"}
+{"name":"Generic1728","regex":"github_ssh_key","confidence":"high"}
+{"name":"Generic1730","regex":"gitlab_private_token","confidence":"high"}
+{"name":"Generic1731","regex":"google_cm","confidence":"low"}
+{"name":"Generic1732","regex":"google_maps_key","confidence":"low"}
+{"name":"Generic1733","regex":"heroku_api_key","confidence":"high"}
+{"name":"Generic1734","regex":"instagram_access_token","confidence":"high"}
+{"name":"Generic1735","regex":"mailchimp_api_key","confidence":"high"}
+{"name":"Generic1736","regex":"mailgun_api_key","confidence":"high"}
+{"name":"Generic1737","regex":"mailjet","confidence":"low"}
+{"name":"Generic1738","regex":"mapbox_access_token","confidence":"low"}
+{"name":"Generic1739","regex":"pagerduty_api_token","confidence":"high"}
+{"name":"Generic1740","regex":"paypal_key_sb","confidence":"high"}
+{"name":"Generic1741","regex":"paypal_key_live","confidence":"high"}
+{"name":"Generic1742","regex":"paypal_token_sb","confidence":"high"}
+{"name":"Generic1743","regex":"paypal_token_live","confidence":"high"}
+{"name":"Generic1744","regex":"pendo_integration_key","confidence":"high"}
+{"name":"Generic1745","regex":"salesforce_access_token","confidence":"high"}
+{"name":"Generic1746","regex":"saucelabs_ukey","confidence":"high"}
+{"name":"Generic1747","regex":"sendgrid_api_key","confidence":"high"}
+{"name":"Generic1748","regex":"slack_api_token","confidence":"high"}
+{"name":"Generic1749","regex":"slack_webhook","confidence":"low"}
+{"name":"Generic1750","regex":"square_secret","confidence":"low"}
+{"name":"Generic1751","regex":"square_auth_token","confidence":"high"}
+{"name":"Generic1752","regex":"travisci_api_token","confidence":"high"}
+{"name":"Generic1753","regex":"twilio_sid_token","confidence":"low"}
+{"name":"Generic1754","regex":"twitter_api_secret","confidence":"high"}
+{"name":"Generic1755","regex":"twitter_bearer_token","confidence":"high"}
+{"name":"Generic1756","regex":"spotify_access_token","confidence":"high"}
+{"name":"Generic1757","regex":"stripe_key_live","confidence":"high"}
+{"name":"Generic1758","regex":"wakatime_api_key","confidence":"high"}
+{"name":"Generic1759","regex":"wompi_auth_bearer_sb","confidence":"high"}
+{"name":"Generic1760","regex":"wompi_auth_bearer_live","confidence":"high"}
+{"name":"Generic1761","regex":"wpengine_api_key","confidence":"high"}
+{"name":"Generic1762","regex":"zapier_webhook","confidence":"low"}
+{"name":"Generic1763","regex":"zendesk_access_token","confidence":"high"}
+{"name":"Generic1764","regex":"ssh-rsa","confidence":"high"}
+{"name":"Generic1765","regex":"s3-[a-z0-9-]+\\.amazonaws\\.com\/[a-z0-9._-]+","confidence":"low"}
+{"name":"GenericSecret","regex":"[sS][eE][cC][rR][eE][tT].*['|\"][0-9a-zA-Z]{32,45}['|\"]","confidence":"low"}
+{"name":"GenericWebhookSecret","regex":"(webhook).+(secret|token|key).+","confidence":"low"}
+{"name":"Gengo","regex":"(?:gengo).{0,40}([ ]{0,1}[0-9a-zA-Z\\[\\]\\-\\(\\)\\{\\}|_^@$=~]{64}[ \\r\\n]{1})","confidence":"high"}
+{"name":"Geoapify","regex":"(?:geoapify).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Geocode","regex":"(?:geocode).{0,40}\\b([a-z0-9]{28})\\b","confidence":"high"}
+{"name":"Geocodify","regex":"(?:geocodify).{0,40}\\b([0-9a-z]{40})\\b","confidence":"high"}
+{"name":"Geocodio2","regex":"(?:geocod).{0,40}\\b([a-z0-9]{39})\\b","confidence":"high"}
+{"name":"Geoipifi","regex":"(?:ipifi).{0,40}\\b([a-z0-9A-Z_]{32})\\b","confidence":"high"}
+{"name":"Getemail","regex":"(?:getemail).{0,40}\\b([a-zA-Z0-9-]{20})\\b","confidence":"high"}
+{"name":"Getemails1","regex":"(?:getemails).{0,40}\\b([a-z0-9-]{26})\\b","confidence":"high"}
+{"name":"Getemails2","regex":"(?:getemails).{0,40}\\b([a-z0-9-]{18})\\b","confidence":"high"}
+{"name":"Getgeoapi","regex":"(?:getgeoapi).{0,40}\\b([0-9a-z]{40})\\b","confidence":"high"}
+{"name":"Getgist","regex":"(?:getgist).{0,40}\\b([a-z0-9A-Z+=]{68})","confidence":"high"}
+{"name":"Getsandbox1","regex":"(?:getsandbox).{0,40}\\b([a-z0-9-]{40})\\b","confidence":"high"}
+{"name":"Getsandbox2","regex":"(?:getsandbox).{0,40}\\b([a-z0-9-]{15,30})\\b","confidence":"high"}
+{"name":"GhApiKey","regex":"gh[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"GhEmail","regex":"gh[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GhNextOauthClientSecret","regex":"gh[_-]?next[_-]?oauth[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GhNextUnstableOauthClientId","regex":"gh[_-]?next[_-]?unstable[_-]?oauth[_-]?client[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GhNextUnstableOauthClientSecret","regex":"gh[_-]?next[_-]?unstable[_-]?oauth[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GhOauthClientSecret","regex":"gh[_-]?oauth[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GhOauthToken","regex":"gh[_-]?oauth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GhRepoToken","regex":"gh[_-]?repo[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GhToken","regex":"gh[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GhUnstableOauthClientSecret","regex":"gh[_-]?unstable[_-]?oauth[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GhbToken","regex":"ghb[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GhostApiKey","regex":"ghost[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GitAuthorEmail","regex":"git[_-]?author[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GitAuthorName","regex":"git[_-]?author[_-]?name(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GitCommitterEmail","regex":"git[_-]?committer[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GitCommitterName","regex":"git[_-]?committer[_-]?name(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GitEmail","regex":"git[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GitName","regex":"git[_-]?name(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GitToken","regex":"git[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Github","regex":"[gG][iI][tT][hH][uU][bB].*['|\"][0-9a-zA-Z]{35,40}['|\"]","confidence":"low"}
+{"name":"Github2","regex":"\\b((?:ghp|gho|ghu|ghs|ghr)_[a-zA-Z0-9]{36,255}\\b)","confidence":"high"}
+{"name":"GithubAccessToken1","regex":"github[_-]?access[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubAccessToken2","regex":"[a-zA-Z0-9_-]*:[a-zA-Z0-9_-]+@github.com*","confidence":"low"}
+{"name":"GithubApiKey","regex":"github[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"GithubApiToken","regex":"github[_-]?api[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubAppToken","regex":"(ghu|ghs)_[0-9a-zA-Z]{36}","confidence":"high"}
+{"name":"GithubAuth","regex":"github[_-]?auth(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubAuthToken","regex":"github[_-]?auth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubClientSecret","regex":"github[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubDeployHbDocPass","regex":"github[_-]?deploy[_-]?hb[_-]?doc[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubDeploymentToken","regex":"github[_-]?deployment[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubHunterToken","regex":"github[_-]?hunter[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubHunterUsername","regex":"github[_-]?hunter[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubKey","regex":"github[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubOauth","regex":"github[_-]?oauth(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"GithubOauthAccessToken","regex":"gho_[0-9a-zA-Z]{36}","confidence":"high"}
+{"name":"GithubOauthToken","regex":"github[_-]?oauth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubOld","regex":"(?:github)[^\\.].{0,40}[ =:'\"]+([a-f0-9]{40})\\b","confidence":"high"}
+{"name":"GithubPassword","regex":"github[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubPersonalAccessToken","regex":"ghp_[0-9a-zA-Z]{36}","confidence":"high"}
+{"name":"GithubPwd","regex":"github[_-]?pwd(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubRefreshToken","regex":"ghr_[0-9a-zA-Z]{76}","confidence":"high"}
+{"name":"GithubReleaseToken","regex":"github[_-]?release[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubRepo","regex":"github[_-]?repo(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GithubToken","regex":"github[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"GithubTokens","regex":"github[_-]?tokens(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Githubapp1","regex":"(?:github).{0,40}\\b([0-9]{6})\\b","confidence":"low"}
+{"name":"Githubapp2","regex":"(?:github).{0,40}(-----BEGIN RSA PRIVATE KEY-----\\s[A-Za-z0-9+\\\/\\s]*\\s-----END RSA PRIVATE KEY-----)","confidence":"high"}
+{"name":"Gitlab","regex":"(?:gitlab).{0,40}\\b([a-zA-Z0-9\\-=_]{20,22})\\b","confidence":"low"}
+{"name":"GitlabUserEmail","regex":"gitlab[_-]?user[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Gitlabv2","regex":"\\b(glpat-[a-zA-Z0-9\\-=_]{20,22})\\b","confidence":"high"}
+{"name":"Gitter","regex":"(?:gitter).{0,40}\\b([a-z0-9-]{40})\\b","confidence":"high"}
+{"name":"Glassnode","regex":"(?:glassnode).{0,40}\\b([0-9A-Za-z]{27})\\b","confidence":"high"}
+{"name":"Gocanvas1","regex":"(?:gocanvas).{0,40}\\b([0-9A-Za-z\/+]{43}=[ \\r\\n]{1})","confidence":"high"}
+{"name":"Gocanvas2","regex":"(?:gocanvas).{0,40}\\b([\\w\\.-]+@[\\w-]+\\.[\\w\\.-]{2,5})\\b","confidence":"high"}
+{"name":"Gocardless","regex":"\\b(live_[0-9A-Za-z\\_\\-]{40}[ \"'\\r\\n]{1})","confidence":"high"}
+{"name":"GogsPassword","regex":"gogs[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Goodday","regex":"(?:goodday).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"GoogleAccountType","regex":"google[_-]?account[_-]?type(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GoogleApiKey","regex":"AIza[0-9a-z-_]{35}","confidence":"high"}
+{"name":"GoogleCalendarUri","regex":"https:\/\/www\\.google\\.com\/calendar\/embed\\?src=[A-Za-z0-9%@&;=\\-_\\.\/]+","confidence":"high"}
+{"name":"GoogleClientEmail","regex":"google[_-]?client[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GoogleClientId","regex":"google[_-]?client[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"GoogleClientSecret","regex":"google[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"GoogleGcpServiceAccount","regex":"\"type\": \"service_account\"","confidence":"high"}
+{"name":"GoogleMapsApiKey","regex":"google[_-]?maps[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"GoogleOauth","regex":"(ya29.[0-9A-Za-z-_]+)","confidence":"high"}
+{"name":"GoogleOauthAccessToken","regex":"ya29\\.[0-9A-Za-z\\-_]+","confidence":"high"}
+{"name":"GooglePatterns","regex":"(?:google_client_id|google_client_secret|google_client_token)","confidence":"low"}
+{"name":"GooglePrivateKey","regex":"google[_-]?private[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GoogleUrl","regex":"([0-9]{12}-[a-z0-9]{32}.apps.googleusercontent.com)","confidence":"low"}
+{"name":"GpgKeyName","regex":"gpg[_-]?key[_-]?name(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GpgKeyname","regex":"gpg[_-]?keyname(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GpgOwnertrust","regex":"gpg[_-]?ownertrust(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GpgPassphrase","regex":"gpg[_-]?passphrase(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GpgPrivateKey","regex":"gpg[_-]?private[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GpgSecretKeys","regex":"gpg[_-]?secret[_-]?keys(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GradlePublishKey","regex":"gradle[_-]?publish[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GradlePublishSecret","regex":"gradle[_-]?publish[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GradleSigningKeyId","regex":"gradle[_-]?signing[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GradleSigningPassword","regex":"gradle[_-]?signing[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Graphcms1","regex":"(?:graph).{0,40}\\b([a-z0-9]{25})\\b","confidence":"high"}
+{"name":"Graphcms2","regex":"\\b(ey[a-zA-Z0-9]{73}.ey[a-zA-Z0-9]{365}.[a-zA-Z0-9_-]{683})\\b","confidence":"high"}
+{"name":"Graphhopper","regex":"(?:graphhopper).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"GrenGithubToken","regex":"gren[_-]?github[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"GrgitUser","regex":"grgit[_-]?user(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Groovehq","regex":"(?:groove).{0,40}\\b([a-z0-9A-Z]{64})","confidence":"high"}
+{"name":"Guru1","regex":"(?:guru).{0,40}\\b([a-zA-Z0-9]{3,20}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,5})\\b","confidence":"high"}
+{"name":"Guru2","regex":"(?:guru).{0,40}\\b([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\\b","confidence":"high"}
+{"name":"Gyazo","regex":"(?:gyazo).{0,40}\\b([0-9A-Za-z-]{43})\\b","confidence":"high"}
+{"name":"HabAuthToken","regex":"hab[_-]?auth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"HabKey","regex":"hab[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Happi","regex":"(?:happi).{0,40}\\b([a-zA-Z0-9]{56})","confidence":"high"}
+{"name":"Happyscribe","regex":"(?:happyscribe).{0,40}\\b([0-9a-zA-Z]{24})\\b","confidence":"high"}
+{"name":"Harvest1","regex":"(?:harvest).{0,40}\\b([a-z0-9A-Z._]{97})\\b","confidence":"high"}
+{"name":"Harvest2","regex":"(?:harvest).{0,40}\\b([0-9]{4,9})\\b","confidence":"low"}
+{"name":"HbCodesignGpgPass","regex":"hb[_-]?codesign[_-]?gpg[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"HbCodesignKeyPass","regex":"hb[_-]?codesign[_-]?key[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Hellosign","regex":"(?:hellosign).{0,40}\\b([a-zA-Z-0-9\/+]{64})\\b","confidence":"high"}
+{"name":"Helpcrunch","regex":"(?:helpcrunch).{0,40}\\b([a-zA-Z-0-9+\/=]{328})","confidence":"high"}
+{"name":"Helpscout","regex":"(?:helpscout).{0,40}\\b([A-Za-z0-9]{56})\\b","confidence":"high"}
+{"name":"Hereapi","regex":"(?:hereapi).{0,40}\\b([a-zA-Z0-9\\S]{43})\\b","confidence":"high"}
+{"name":"Heroku","regex":"(?:heroku).{0,40}\\b([0-9Aa-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b","confidence":"high"}
+{"name":"HerokuApiKey","regex":"heroku[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"HerokuApiKeyApiKey","regex":"([h|H][e|E][r|R][o|O][k|K][u|U].{0,30}[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})","confidence":"low"}
+{"name":"HerokuEmail","regex":"heroku[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"HerokuToken","regex":"heroku[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Hive1","regex":"(?:hive).{0,40}\\b([0-9a-z]{32})\\b","confidence":"low"}
+{"name":"Hive2","regex":"(?:hive).{0,40}\\b([0-9A-Za-z]{17})\\b","confidence":"high"}
+{"name":"Hiveage","regex":"(?:hiveage).{0,40}\\b([0-9A-Za-z\\_\\-]{20})\\b","confidence":"high"}
+{"name":"Hockeyapp","regex":"hockey.{0,50}(\"|')?[0-9a-f]{32}(\"|')?","confidence":"low"}
+{"name":"HockeyappToken","regex":"hockeyapp[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Holidayapi","regex":"(?:holidayapi).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"HomebrewGithubApiToken","regex":"homebrew[_-]?github[_-]?api[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Host","regex":"(?:host).{0,40}\\b([a-z0-9]{14})\\b","confidence":"low"}
+{"name":"Html2Pdf","regex":"(?:html2pdf).{0,40}\\b([a-zA-Z0-9]{64})\\b","confidence":"high"}
+{"name":"HubDxia2Password","regex":"hub[_-]?dxia2[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Hubspotapikey","regex":"(?:hubspot).{0,40}\\b([A-Za-z0-9]{8}\\-[A-Za-z0-9]{4}\\-[A-Za-z0-9]{4}\\-[A-Za-z0-9]{4}\\-[A-Za-z0-9]{12})\\b","confidence":"high"}
+{"name":"Humanity","regex":"(?:humanity).{0,40}\\b([0-9a-z]{40})\\b","confidence":"high"}
+{"name":"Hunter","regex":"(?:hunter).{0,40}\\b([a-z0-9_-]{40})\\b","confidence":"low"}
+{"name":"Hypertrack1","regex":"(?:hypertrack).{0,40}\\b([0-9a-zA-Z\\_\\-]{54})\\b","confidence":"high"}
+{"name":"Hypertrack2","regex":"(?:hypertrack).{0,40}\\b([0-9a-zA-Z\\_\\-]{27})\\b","confidence":"high"}
+{"name":"Ibmclouduserkey","regex":"(?:ibm).{0,40}\\b([A-Za-z0-9_-]{44})\\b","confidence":"high"}
+{"name":"Iconfinder","regex":"(?:iconfinder).{0,40}\\b([a-zA-Z0-9]{64})\\b","confidence":"high"}
+{"name":"Iexcloud","regex":"(?:iexcloud).{0,40}\\b([a-z0-9_]{35})\\b","confidence":"high"}
+{"name":"IjRepoPassword","regex":"ij[_-]?repo[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"IjRepoUsername","regex":"ij[_-]?repo[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Imagekit","regex":"(?:imagekit).{0,40}\\b([a-zA-Z0-9_=]{36})","confidence":"high"}
+{"name":"Imagga","regex":"(?:imagga).{0,40}\\b([a-z0-9A-Z=]{72})","confidence":"high"}
+{"name":"Impala","regex":"(?:impala).{0,40}\\b([0-9A-Za-z_]{46})\\b","confidence":"high"}
+{"name":"IndexName","regex":"index[_-]?name(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Insightly","regex":"(?:insightly).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"IntegrationTestApiKey","regex":"integration[_-]?test[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"IntegrationTestAppid","regex":"integration[_-]?test[_-]?appid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Integromat","regex":"(?:integromat).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"Intercom","regex":"(?:intercom).{0,40}\\b([a-zA-Z0-9\\W\\S]{59}\\=)","confidence":"low"}
+{"name":"InternalSecrets","regex":"internal[_-]?secrets(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Intrinio","regex":"(?:intrinio).{0,40}\\b([a-zA-Z0-9]{44})\\b","confidence":"high"}
+{"name":"Invoiceocean1","regex":"(?:invoiceocean).{0,40}\\b([0-9A-Za-z]{20})\\b","confidence":"high"}
+{"name":"Invoiceocean2","regex":"\\b([0-9a-z]{1,}.invoiceocean.com)\\b","confidence":"high"}
+{"name":"IosDocsDeployToken","regex":"ios[_-]?docs[_-]?deploy[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Ipapi","regex":"(?:ipapi).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Ipgeolocation","regex":"(?:ipgeolocation).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Ipify","regex":"(?:ipify).{0,40}\\b([a-zA-Z0-9_-]{32})\\b","confidence":"high"}
+{"name":"Ipinfodb","regex":"(?:ipinfodb).{0,40}\\b([a-z0-9]{64})\\b","confidence":"high"}
+{"name":"Ipquality","regex":"(?:ipquality).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Ipstack","regex":"(?:ipstack).{0,40}\\b([a-fA-f0-9]{32})\\b","confidence":"high"}
+{"name":"ItestGhToken","regex":"itest[_-]?gh[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Jdbc","regex":"mysql: jdbc:mysql(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"JdbcConnectionString","regex":"jdbc:[a-z:]+:\/\/[A-Za-z0-9\\.\\-_:;=\/@?,&]+","confidence":"high"}
+{"name":"JdbcDatabaseurl","regex":"jdbc[_-]?databaseurl(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"JdbcHost","regex":"jdbc[_-]?host(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Jiratoken1","regex":"(?:jira).{0,40}\\b([a-zA-Z-0-9]{24})\\b","confidence":"high"}
+{"name":"Jiratoken2","regex":"(?:jira).{0,40}\\b([a-zA-Z-0-9]{5,24}\\@[a-zA-Z-0-9]{3,16}\\.com)\\b","confidence":"high"}
+{"name":"Jiratoken3","regex":"(?:jira).{0,40}\\b([a-zA-Z-0-9]{5,24}\\.[a-zA-Z-0-9]{3,16}\\.[a-zA-Z-0-9]{3,16})\\b","confidence":"low"}
+{"name":"Jotform","regex":"(?:jotform).{0,40}\\b([0-9Aa-z]{32})\\b","confidence":"high"}
+{"name":"Jumpcloud","regex":"(?:jumpcloud).{0,40}\\b([a-zA-Z0-9]{40})\\b","confidence":"high"}
+{"name":"Juro","regex":"(?:juro).{0,40}\\b([a-zA-Z0-9]{40})\\b","confidence":"high"}
+{"name":"JwtSecret","regex":"jwt[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"KafkaAdminUrl","regex":"kafka[_-]?admin[_-]?url(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"KafkaInstanceName","regex":"kafka[_-]?instance[_-]?name(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"KafkaRestUrl","regex":"kafka[_-]?rest[_-]?url(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Kanban1","regex":"(?:kanban).{0,40}\\b([0-9A-Z]{12})\\b","confidence":"high"}
+{"name":"Kanban2","regex":"\\b([0-9a-z]{1,}.kanbantool.com)\\b","confidence":"high"}
+{"name":"Karmacrm","regex":"(?:karma).{0,40}\\b([a-zA-Z0-9]{20})\\b","confidence":"high"}
+{"name":"Keenio1","regex":"(?:keen).{0,40}\\b([0-9a-z]{24})\\b","confidence":"high"}
+{"name":"Keenio2","regex":"(?:keen).{0,40}\\b([0-9A-Z]{64})\\b","confidence":"high"}
+{"name":"KeystorePass","regex":"keystore[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Kickbox","regex":"(?:kickbox).{0,40}\\b([a-zA-Z0-9_]+[a-zA-Z0-9]{64})\\b","confidence":"high"}
+{"name":"Klipfolio","regex":"(?:klipfolio).{0,40}\\b([0-9a-f]{40})\\b","confidence":"high"}
+{"name":"Kontent","regex":"(?:kontent).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"KovanPrivateKey","regex":"kovan[_-]?private[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Kraken1","regex":"(?:kraken).{0,40}\\b([0-9A-Za-z\\\/\\+=]{56}[ \"'\\r\\n]{1})","confidence":"high"}
+{"name":"Kraken2","regex":"(?:kraken).{0,40}\\b([0-9A-Za-z\\\/\\+=]{86,88}[ \"'\\r\\n]{1})","confidence":"high"}
+{"name":"KubecfgS3Path","regex":"kubecfg[_-]?s3[_-]?path(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Kubeconfig","regex":"kubeconfig(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Kucoin1","regex":"(?:kucoin).{0,40}([ \\r\\n]{1}[!-~]{7,32}[ \\r\\n]{1})","confidence":"high"}
+{"name":"Kucoin2","regex":"(?:kucoin).{0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b","confidence":"high"}
+{"name":"Kucoin3","regex":"(?:kucoin).{0,40}\\b([0-9a-f]{24})\\b","confidence":"high"}
+{"name":"Kxoltsn3Vogdop92M","regex":"kxoltsn3vogdop92m(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Kylas","regex":"(?:kylas).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"Languagelayer","regex":"(?:languagelayer).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Lastfm","regex":"(?:lastfm).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Launchdarkly","regex":"(?:launchdarkly).{0,40}\\b([a-z0-9-]{40})\\b","confidence":"high"}
+{"name":"Leadfeeder","regex":"(?:leadfeeder).{0,40}\\b([a-zA-Z0-9-]{43})\\b","confidence":"high"}
+{"name":"LeanplumKey","regex":"leanplum[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"LektorDeployPassword","regex":"lektor[_-]?deploy[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"LektorDeployUsername","regex":"lektor[_-]?deploy[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Lendflow","regex":"(?:lendflow).{0,40}\\b([a-zA-Z0-9]{36}\\.[a-zA-Z0-9]{235}\\.[a-zA-Z0-9]{32}\\-[a-zA-Z0-9]{47}\\-[a-zA-Z0-9_]{162}\\-[a-zA-Z0-9]{42}\\-[a-zA-Z0-9_]{40}\\-[a-zA-Z0-9_]{66}\\-[a-zA-Z0-9_]{59}\\-[a-zA-Z0-9]{7}\\-[a-zA-Z0-9_]{220})\\b","confidence":"high"}
+{"name":"Lessannoyingcrm","regex":"(?:less).{0,40}\\b([a-zA-Z0-9-]{57})\\b","confidence":"low"}
+{"name":"Lexigram","regex":"(?:lexigram).{0,40}\\b([a-zA-Z0-9\\S]{301})\\b","confidence":"high"}
+{"name":"LighthouseApiKey","regex":"lighthouse[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Linearapi","regex":"\\b(lin_api_[0-9A-Za-z]{40})\\b","confidence":"high"}
+{"name":"Linemessaging","regex":"(?:line).{0,40}\\b([A-Za-z0-9+\/]{171,172})\\b","confidence":"high"}
+{"name":"Linenotify","regex":"(?:linenotify).{0,40}\\b([0-9A-Za-z]{43})\\b","confidence":"high"}
+{"name":"Linkpreview","regex":"(?:linkpreview).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"LinuxSigningKey","regex":"linux[_-]?signing[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Liveagent","regex":"(?:liveagent).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Livestorm","regex":"(?:livestorm).{0,40}\\b(eyJhbGciOiJIUzI1NiJ9\\.eyJhdWQiOiJhcGkubGl2ZXN0b3JtLmNvIiwianRpIjoi[0-9A-Z-a-z]{134}\\.[0-9A-Za-z\\-\\_]{43}[ \\r\\n]{1})","confidence":"high"}
+{"name":"LlPublishUrl","regex":"ll[_-]?publish[_-]?url(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"LlSharedKey","regex":"ll[_-]?shared[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Locationiq","regex":"\\b(pk\\.[a-zA-Z-0-9]{32})\\b","confidence":"high"}
+{"name":"Loginradius","regex":"(?:loginradius).{0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b","confidence":"high"}
+{"name":"Lokalisetoken","regex":"(?:lokalise).{0,40}\\b([a-z0-9]{40})\\b","confidence":"high"}
+{"name":"LookerTestRunnerClientSecret","regex":"looker[_-]?test[_-]?runner[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"LottieHappoApiKey","regex":"lottie[_-]?happo[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"LottieHappoSecretKey","regex":"lottie[_-]?happo[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"LottieS3SecretKey","regex":"lottie[_-]?s3[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"LottieUploadCertKeyPassword","regex":"lottie[_-]?upload[_-]?cert[_-]?key[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"LottieUploadCertKeyStorePassword","regex":"lottie[_-]?upload[_-]?cert[_-]?key[_-]?store[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Loyverse","regex":"(?:loyverse).{0,40}\\b([0-9-a-z]{32})\\b","confidence":"high"}
+{"name":"Luno1","regex":"(?:luno).{0,40}\\b([a-z0-9]{13})\\b","confidence":"high"}
+{"name":"Luno2","regex":"(?:luno).{0,40}\\b([a-zA-Z0-9_-]{43})\\b","confidence":"high"}
+{"name":"M3O","regex":"(?:m3o).{0,40}\\b([0-9A-Za-z]{48})\\b","confidence":"low"}
+{"name":"Macaddress","regex":"(?:macaddress).{0,40}\\b([a-zA-Z0-9_]{32})\\b","confidence":"high"}
+{"name":"Madkudu","regex":"(?:madkudu).{0,40}\\b([0-9a-f]{32})\\b","confidence":"high"}
+{"name":"MagentoAuthPassword","regex":"magento[_-]?auth[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MagentoAuthUsername","regex":"magento[_-]?auth[_-]?username (=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MagentoPassword","regex":"magento[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Magnetic","regex":"(?:magnetic).{0,40}\\b([0-9Aa-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b","confidence":"high"}
+{"name":"MailPassword","regex":"mail[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Mailboxlayer","regex":"(?:mailboxlayer).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Mailchimp","regex":"(W(?:[a-f0-9]{32}(-us[0-9]{1,2}))a-zA-Z0-9)","confidence":"high"}
+{"name":"MailchimpApiKey","regex":"mailchimp[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MailchimpKey","regex":"mailchimp[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MailerPassword","regex":"mailer[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Mailerlite","regex":"(?:mailerlite).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Mailgun","regex":"(key-[0-9a-f]{32})","confidence":"low"}
+{"name":"Mailgun2","regex":"(?:mailgun).{0,40}\\b([a-zA-Z-0-9]{72})\\b","confidence":"high"}
+{"name":"MailgunApiKey","regex":"mailgun[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MailgunApiKey1","regex":"key-[0-9a-zA-Z]{32}","confidence":"high"}
+{"name":"MailgunApiKey2","regex":"(mailgun|mg)[0-9a-z]{32}","confidence":"low"}
+{"name":"MailgunApikey","regex":"mailgun[_-]?apikey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MailgunPassword","regex":"mailgun[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MailgunPrivKey","regex":"mailgun[_-]?priv[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"MailgunPubApikey","regex":"mailgun[_-]?pub[_-]?apikey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MailgunPubKey","regex":"mailgun[_-]?pub[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MailgunSecretApiKey","regex":"mailgun[_-]?secret[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Mailjetbasicauth","regex":"(?:mailjet).{0,40}\\b([A-Za-z0-9]{87}\\=)","confidence":"high"}
+{"name":"Mailjetsms","regex":"(?:mailjet).{0,40}\\b([A-Za-z0-9]{32})\\b","confidence":"high"}
+{"name":"Mailmodo","regex":"(?:mailmodo).{0,40}\\b([A-Z0-9]{7}-[A-Z0-9]{7}-[A-Z0-9]{7}-[A-Z0-9]{7})\\b","confidence":"high"}
+{"name":"Mailsac","regex":"(?:mailsac).{0,40}\\b(k_[0-9A-Za-z]{36,})\\b","confidence":"high"}
+{"name":"ManageKey","regex":"manage[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ManageSecret","regex":"manage[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ManagementToken","regex":"management[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Managementapiaccesstoken","regex":"managementapiaccesstoken(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Mandrill","regex":"(?:mandrill).{0,40}\\b([A-Za-z0-9_-]{22})\\b","confidence":"high"}
+{"name":"MandrillApiKey","regex":"mandrill[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Manifest","regex":"(?:manifest).{0,40}\\b([a-zA-z0-9]{32})\\b","confidence":"low"}
+{"name":"ManifestAppToken","regex":"manifest[_-]?app[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ManifestAppUrl","regex":"manifest[_-]?app[_-]?url(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Mapbox2","regex":"\\b(sk\\.[a-zA-Z-0-9\\.]{80,240})\\b","confidence":"high"}
+{"name":"MapboxAccessToken","regex":"mapbox[_-]?access[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MapboxApiToken","regex":"mapbox[_-]?api[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MapboxAwsAccessKeyId","regex":"mapbox[_-]?aws[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MapboxAwsSecretAccessKey","regex":"mapbox[_-]?aws[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Mapboxaccesstoken","regex":"mapboxaccesstoken(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Mapquest","regex":"(?:mapquest).{0,40}\\b([0-9A-Za-z]{32})\\b","confidence":"high"}
+{"name":"Marketstack","regex":"(?:marketstack).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"MasterPassword","regex":"(master_password).+","confidence":"high"}
+{"name":"Mattermostpersonaltoken1","regex":"(?:mattermost).{0,40}\\b([A-Za-z0-9-_]{1,}.cloud.mattermost.com)\\b","confidence":"high"}
+{"name":"Mattermostpersonaltoken2","regex":"(?:mattermost).{0,40}\\b([a-z0-9]{26})\\b","confidence":"high"}
+{"name":"Mavenlink","regex":"(?:mavenlink).{0,40}\\b([0-9a-z]{64})\\b","confidence":"high"}
+{"name":"Maxmindlicense1","regex":"(?:maxmind|geoip).{0,40}\\b([0-9A-Za-z]{16})\\b","confidence":"high"}
+{"name":"Maxmindlicense2","regex":"(?:maxmind|geoip).{0,40}\\b([0-9]{2,7})\\b","confidence":"high"}
+{"name":"Meaningcloud","regex":"(?:meaningcloud).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Mediastack","regex":"(?:mediastack).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Meistertask","regex":"(?:meistertask).{0,40}\\b([a-zA-Z0-9]{43})\\b","confidence":"high"}
+{"name":"Mesibo","regex":"(?:mesibo).{0,40}\\b([0-9A-Za-z]{64})\\b","confidence":"high"}
+{"name":"Messagebird","regex":"(?:messagebird).{0,40}\\b([A-Za-z0-9_-]{25})\\b","confidence":"high"}
+{"name":"Metaapi1","regex":"(?:metaapi|meta-api).{0,40}\\b([0-9a-f]{64})\\b","confidence":"high"}
+{"name":"Metaapi2","regex":"(?:metaapi|meta-api).{0,40}\\b([0-9a-f]{24})\\b","confidence":"high"}
+{"name":"Metrilo","regex":"(?:metrilo).{0,40}\\b([a-z0-9]{16})\\b","confidence":"high"}
+{"name":"MgApiKey","regex":"mg[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MgPublicApiKey","regex":"mg[_-]?public[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"MhApikey","regex":"mh[_-]?apikey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MhPassword","regex":"mh[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MicrosoftTeamsWebhook","regex":"https:\/\/outlook\\.office\\.com\/webhook\/[A-Za-z0-9\\-@]+\/IncomingWebhook\/[A-Za-z0-9\\-]+\/[A-Za-z0-9\\-]+","confidence":"low"}
+{"name":"Microsoftteamswebhook","regex":"(https:\\\/\\\/[a-zA-Z-0-9]+\\.webhook\\.office\\.com\\\/webhookb2\\\/[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12}\\@[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12}\\\/IncomingWebhook\\\/[a-zA-Z-0-9]{32}\\\/[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12})","confidence":"high"}
+{"name":"Midise","regex":"midi-662b69edd2[a-zA-Z0-9]{54}","confidence":"high"}
+{"name":"MileZeroKey","regex":"mile[_-]?zero[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Mindmeister","regex":"(?:mindmeister).{0,40}\\b([a-zA-Z0-9]{43})\\b","confidence":"high"}
+{"name":"MinioAccessKey","regex":"minio[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MinioSecretKey","regex":"minio[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Mite1","regex":"(?:mite).{0,40}\\b([0-9a-z]{16})\\b","confidence":"high"}
+{"name":"Mite2","regex":"\\b([0-9a-z-]{1,}.mite.yo.lk)\\b","confidence":"high"}
+{"name":"Mixmax","regex":"(?:mixmax).{0,40}\\b([a-zA-Z0-9_-]{36})\\b","confidence":"high"}
+{"name":"Mixpanel1","regex":"(?:mixpanel).{0,40}\\b([a-zA-Z0-9.-]{30,40})\\b","confidence":"high"}
+{"name":"Mixpanel2","regex":"(?:mixpanel).{0,40}\\b([a-zA-Z0-9-]{32})\\b","confidence":"high"}
+{"name":"Moderation","regex":"(?:moderation).{0,40}\\b([a-zA-Z0-9]{36}\\.[a-zA-Z0-9]{115}\\.[a-zA-Z0-9_]{43})\\b","confidence":"high"}
+{"name":"Monday","regex":"(?:monday).{0,40}\\b(ey[a-zA-Z0-9_.]{210,225})\\b","confidence":"high"}
+{"name":"Moonclerck","regex":"(?:moonclerck).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Moonclerk","regex":"(?:moonclerk).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Moosend","regex":"(?:moosend).{0,40}\\b([0-9Aa-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b","confidence":"high"}
+{"name":"Mrticktock1","regex":"(?:mrticktock).{0,40}\\b([a-zA-Z0-9!=@#$%()_^]{1,50})","confidence":"high"}
+{"name":"MultiBobSid","regex":"multi[_-]?bob[_-]?sid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MultiConnectSid","regex":"multi[_-]?connect[_-]?sid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MultiDisconnectSid","regex":"multi[_-]?disconnect[_-]?sid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MultiWorkflowSid","regex":"multi[_-]?workflow[_-]?sid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MultiWorkspaceSid","regex":"multi[_-]?workspace[_-]?sid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MySecretEnv","regex":"my[_-]?secret[_-]?env(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Myfreshworks2","regex":"(?:freshworks).{0,40}\\b([a-z0-9A-Z-]{22})\\b","confidence":"low"}
+{"name":"Myintervals","regex":"(?:myintervals).{0,40}\\b([0-9a-z]{11})\\b","confidence":"high"}
+{"name":"MysqlDatabase","regex":"mysql[_-]?database(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MysqlHostname","regex":"mysql[_-]?hostname(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MysqlPassword","regex":"mysql[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MysqlRootPassword","regex":"mysql[_-]?root[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"MysqlUser","regex":"mysql[_-]?user(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"MysqlUsername","regex":"mysql[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Mysqlmasteruser","regex":"mysqlmasteruser(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Mysqlsecret","regex":"mysqlsecret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Nasdaqdatalink","regex":"(?:nasdaq).{0,40}\\b([a-zA-Z0-9_-]{20})\\b","confidence":"high"}
+{"name":"Nativeevents","regex":"nativeevents(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Nethunt1","regex":"(?:nethunt).{0,40}\\b([a-zA-Z0-9.-@]{25,30})\\b","confidence":"high"}
+{"name":"Nethunt2","regex":"(?:nethunt).{0,40}\\b([a-z0-9-\\S]{36})\\b","confidence":"high"}
+{"name":"Netlify","regex":"(?:netlify).{0,40}\\b([A-Za-z0-9_-]{43,45})\\b","confidence":"high"}
+{"name":"NetlifyApiKey","regex":"netlify[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Neutrinoapi1","regex":"(?:neutrinoapi).{0,40}\\b([a-zA-Z0-9]{48})\\b","confidence":"high"}
+{"name":"Neutrinoapi2","regex":"(?:neutrinoapi).{0,40}\\b([a-zA-Z0-9]{6,24})\\b","confidence":"high"}
+{"name":"NewRelicBetaToken","regex":"new[_-]?relic[_-]?beta[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NewrelicAdminApiKey","regex":"NRAA-[a-f0-9]{27}","confidence":"high"}
+{"name":"NewrelicInsightsApiKey","regex":"NRI(?:I|Q)-[A-Za-z0-9\\-_]{32}","confidence":"high"}
+{"name":"NewrelicRestApiKey","regex":"NRRA-[a-f0-9]{42}","confidence":"high"}
+{"name":"NewrelicSyntheticsLocationKey","regex":"NRSP-[a-z]{2}[0-9]{2}[a-f0-9]{31}","confidence":"high"}
+{"name":"Newrelicpersonalapikey","regex":"(?:newrelic).{0,40}\\b([A-Za-z0-9_\\.]{4}-[A-Za-z0-9_\\.]{42})\\b","confidence":"high"}
+{"name":"Newsapi","regex":"(?:newsapi).{0,40}\\b([a-z0-9]{32})","confidence":"high"}
+{"name":"Newscatcher","regex":"(?:newscatcher).{0,40}\\b([0-9A-Za-z_]{43})\\b","confidence":"high"}
+{"name":"Nexmoapikey1","regex":"(?:nexmo).{0,40}\\b([A-Za-z0-9_-]{8})\\b","confidence":"high"}
+{"name":"Nexmoapikey2","regex":"(?:nexmo).{0,40}\\b([A-Za-z0-9_-]{16})\\b","confidence":"high"}
+{"name":"NexusPassword","regex":"nexus[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Nexuspassword","regex":"nexuspassword(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Nftport","regex":"(?:nftport).{0,40}\\b([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\\b","confidence":"high"}
+{"name":"NgrokAuthToken","regex":"ngrok[_-]?auth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NgrokToken","regex":"ngrok[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Nicereply","regex":"(?:nicereply).{0,40}\\b([0-9a-f]{40})\\b","confidence":"high"}
+{"name":"Nimble","regex":"(?:nimble).{0,40}\\b([a-zA-Z0-9]{30})\\b","confidence":"high"}
+{"name":"Nitro","regex":"(?:nitro).{0,40}\\b([0-9a-f]{32})\\b","confidence":"high"}
+{"name":"NodeEnv","regex":"node[_-]?env(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NodePreGypAccesskeyid","regex":"node[_-]?pre[_-]?gyp[_-]?accesskeyid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NodePreGypGithubToken","regex":"node[_-]?pre[_-]?gyp[_-]?github[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NodePreGypSecretaccesskey","regex":"node[_-]?pre[_-]?gyp[_-]?secretaccesskey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NonToken","regex":"non[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Noticeable","regex":"(?:noticeable).{0,40}\\b([0-9a-zA-Z]{20})\\b","confidence":"high"}
+{"name":"Notion","regex":"\\b(secret_[A-Za-z0-9]{43})\\b","confidence":"high"}
+{"name":"NowToken","regex":"now[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Nozbeteams","regex":"(?:nozbe|nozbeteams).{0,40}\\b([0-9A-Za-z]{16}_[0-9A-Za-z\\-_]{64}[ \\r\\n]{1})","confidence":"high"}
+{"name":"NpmApiKey","regex":"npm[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NpmApiToken","regex":"npm[_-]?api[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NpmAuthToken","regex":"npm[_-]?auth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NpmEmail","regex":"npm[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NpmPassword","regex":"npm[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NpmSecretKey","regex":"npm[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NpmToken1","regex":"npm[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NugetApiKey1","regex":"(oy2[a-z0-9]{43})","confidence":"low"}
+{"name":"NugetApiKey2","regex":"nuget[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"NumbersServicePass","regex":"numbers[_-]?service[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Numverify","regex":"(?:numverify).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Nutritionix1","regex":"(?:nutritionix).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Nutritionix2","regex":"(?:nutritionix).{0,40}\\b([a-z0-9]{8})\\b","confidence":"high"}
+{"name":"Nylas","regex":"(?:nylas).{0,40}\\b([0-9A-Za-z]{30})\\b","confidence":"high"}
+{"name":"Nytimes","regex":"(?:nytimes).{0,40}\\b([a-z0-9A-Z-]{32})\\b","confidence":"low"}
+{"name":"Oanda","regex":"(?:oanda).{0,40}\\b([a-zA-Z0-9]{24})\\b","confidence":"high"}
+{"name":"OauthToken","regex":"oauth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ObjectStoragePassword","regex":"object[_-]?storage[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ObjectStorageRegionName","regex":"object[_-]?storage[_-]?region[_-]?name(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ObjectStoreBucket","regex":"object[_-]?store[_-]?bucket(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ObjectStoreCreds","regex":"object[_-]?store[_-]?creds(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OcPass","regex":"oc[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OctestAppPassword","regex":"octest[_-]?app[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OctestAppUsername","regex":"octest[_-]?app[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OctestPassword","regex":"octest[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OftaKey","regex":"ofta[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OftaRegion","regex":"ofta[_-]?region(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OftaSecret","regex":"ofta[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OktaClientToken","regex":"okta[_-]?client[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OktaOauth2ClientSecret","regex":"okta[_-]?oauth2[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OktaOauth2Clientsecret","regex":"okta[_-]?oauth2[_-]?clientsecret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OmiseKey","regex":"omise[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OmisePkey","regex":"omise[_-]?pkey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OmisePubkey","regex":"omise[_-]?pubkey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OmiseSkey","regex":"omise[_-]?skey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Omnisend","regex":"(?:omnisend).{0,40}\\b([a-z0-9A-Z-]{75})\\b","confidence":"high"}
+{"name":"Onedesk1","regex":"(?:onedesk).{0,40}\\b([a-zA-Z0-9!=@#$%^]{8,64})","confidence":"high"}
+{"name":"Onelogin2","regex":"secret[a-zA-Z0-9_' \"=]{0,20}([a-z0-9]{64})","confidence":"high"}
+{"name":"Onepagecrm1","regex":"(?:onepagecrm).{0,40}\\b([a-zA-Z0-9=]{44})","confidence":"high"}
+{"name":"Onepagecrm2","regex":"(?:onepagecrm).{0,40}\\b([a-z0-9]{24})\\b","confidence":"high"}
+{"name":"OnesignalApiKey","regex":"onesignal[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OnesignalUserAuthKey","regex":"onesignal[_-]?user[_-]?auth[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Onwaterio","regex":"(?:onwater).{0,40}\\b([a-zA-Z0-9_-]{20})\\b","confidence":"high"}
+{"name":"Oopspam","regex":"(?:oopspam).{0,40}\\b([a-zA-Z0-9]{40})\\b","confidence":"high"}
+{"name":"OpenaiApiKey","regex":"sk-[A-Za-z0-9-_]*[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}","confidence":"high"}
+{"name":"OpenWhiskKey","regex":"open[_-]?whisk[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Opencagedata","regex":"(?:opencagedata).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Opengraphr","regex":"(?:opengraphr).{0,40}\\b([0-9Aa-zA-Z]{80})\\b","confidence":"high"}
+{"name":"Openuv","regex":"(?:openuv).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Openweather","regex":"(?:openweather).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"OpenwhiskKey","regex":"openwhisk[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Optimizely","regex":"(?:optimizely).{0,40}\\b([0-9A-Za-z-:]{54})\\b","confidence":"high"}
+{"name":"OsAuthUrl","regex":"os[_-]?auth[_-]?url(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OsPassword","regex":"os[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OssrhJiraPassword","regex":"ossrh[_-]?jira[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OssrhPass","regex":"ossrh[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OssrhPassword","regex":"ossrh[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OssrhSecret","regex":"ossrh[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OssrhUsername","regex":"ossrh[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"OutlookTeam","regex":"(https:\/\/outlook.office.com\/webhook\/[0-9a-f-]{36}@)","confidence":"low"}
+{"name":"Owlbot","regex":"(?:owlbot).{0,40}\\b([a-z0-9]{40})\\b","confidence":"high"}
+{"name":"PackagecloudToken","regex":"packagecloud[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PagerdutyApikey","regex":"pagerduty[_-]?apikey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Pagerdutyapikey","regex":"(?:pagerduty).{0,40}\\b([a-z]{1}\\+[a-zA-Z]{9}\\-[a-z]{2}\\-[a-z0-9]{5})\\b","confidence":"high"}
+{"name":"Pandadoc","regex":"(?:pandadoc).{0,40}\\b([a-zA-Z0-9]{40})\\b","confidence":"high"}
+{"name":"Pandascore","regex":"(?:pandascore).{0,40}([ \\r\\n]{0,1}[0-9A-Za-z\\-\\_]{51}[ \\r\\n]{1})","confidence":"high"}
+{"name":"Paralleldots","regex":"(?:paralleldots).{0,40}\\b([0-9A-Za-z]{43})\\b","confidence":"high"}
+{"name":"ParseJsKey","regex":"parse[_-]?js[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Partnerstack","regex":"(?:partnerstack).{0,40}\\b([0-9A-Za-z]{64})\\b","confidence":"high"}
+{"name":"Passbase","regex":"(?:passbase).{0,40}\\b([a-zA-Z0-9]{128})\\b","confidence":"high"}
+{"name":"PasswordInUrl","regex":"[a-zA-Z]{3,10}:\/\/[^\/\\s:@]{3,20}:[^\/\\s:@]{3,20}@.{1,100}[\"'\\s]","confidence":"high"}
+{"name":"Passwordtravis","regex":"passwordtravis(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Pastebin","regex":"(?:pastebin).{0,40}\\b([a-zA-Z0-9_]{32})\\b","confidence":"high"}
+{"name":"Paymoapp","regex":"(?:paymoapp).{0,40}\\b([a-zA-Z0-9]{44})\\b","confidence":"high"}
+{"name":"Paymongo","regex":"(?:paymongo).{0,40}\\b([a-zA-Z0-9_]{32})\\b","confidence":"high"}
+{"name":"PaypalClientSecret","regex":"paypal[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Paypaloauth1","regex":"\\b([A-Za-z0-9_\\.]{7}-[A-Za-z0-9_\\.]{72})\\b","confidence":"low"}
+{"name":"Paypaloauth2","regex":"\\b([A-Za-z0-9_\\.]{69}-[A-Za-z0-9_\\.]{10})\\b","confidence":"low"}
+{"name":"Paystack","regex":"\\b(sk\\_[a-z]{1,}\\_[A-Za-z0-9]{40})\\b","confidence":"high"}
+{"name":"Pdflayer","regex":"(?:pdflayer).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Pdfshift","regex":"(?:pdfshift).{0,40}\\b([0-9a-f]{32})\\b","confidence":"high"}
+{"name":"Peopledatalabs","regex":"(?:peopledatalabs).{0,40}\\b([a-z0-9]{64})\\b","confidence":"high"}
+{"name":"Pepipost","regex":"(?:pepipost|netcore).{0,40}\\b([a-zA-Z-0-9]{32})\\b","confidence":"high"}
+{"name":"PercyProject","regex":"percy[_-]?project(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PercyToken","regex":"percy[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PersonalKey","regex":"personal[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PersonalSecret","regex":"personal[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PgDatabase","regex":"pg[_-]?database(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PgHost","regex":"pg[_-]?host(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PgpPrivateKeyBlock","regex":"-----BEGIN PGP PRIVATE KEY BLOCK-----","confidence":"high"}
+{"name":"PicaticApiKey","regex":"sk_live_[0-9a-z]{32}","confidence":"high"}
+{"name":"Pipedream","regex":"(?:pipedream).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Pipedrive","regex":"(?:pipedrive).{0,40}\\b([a-zA-Z0-9]{40})\\b","confidence":"high"}
+{"name":"Pivotaltracker","regex":"(?:pivotal).{0,40}([a-z0-9]{32})","confidence":"high"}
+{"name":"Pixabay","regex":"(?:pixabay).{0,40}\\b([a-z0-9-]{34})\\b","confidence":"high"}
+{"name":"PlacesApiKey","regex":"places[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PlacesApikey","regex":"places[_-]?apikey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Plaidkey1","regex":"(?:plaid).{0,40}\\b([a-z0-9]{24})\\b","confidence":"high"}
+{"name":"Plaidkey2","regex":"(?:plaid).{0,40}\\b([a-z0-9]{30})\\b","confidence":"high"}
+{"name":"Planviewleankit1","regex":"(?:planviewleankit|planview).{0,40}\\b([0-9a-f]{128})\\b","confidence":"high"}
+{"name":"Planviewleankit2","regex":"(?:planviewleankit|planview).{0,40}(?:subdomain).\\b([a-zA-Z][a-zA-Z0-9.-]{1,23}[a-zA-Z0-9])\\b","confidence":"high"}
+{"name":"Planyo","regex":"(?:planyo).{0,40}\\b([0-9a-z]{62})\\b","confidence":"high"}
+{"name":"Plivo1","regex":"(?:plivo).{0,40}\\b([A-Za-z0-9_-]{40})\\b","confidence":"high"}
+{"name":"Plivo2","regex":"(?:plivo).{0,40}\\b([A-Z]{20})\\b","confidence":"high"}
+{"name":"PlotlyApikey","regex":"plotly[_-]?apikey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PluginPassword","regex":"plugin[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Poloniex1","regex":"(?:poloniex).{0,40}\\b([0-9a-f]{128})\\b","confidence":"high"}
+{"name":"Poloniex2","regex":"(?:poloniex).{0,40}\\b([0-9A-Z]{8}-[0-9A-Z]{8}-[0-9A-Z]{8}-[0-9A-Z]{8})\\b","confidence":"high"}
+{"name":"Polygon","regex":"(?:polygon).{0,40}\\b([a-z0-9A-Z]{32})\\b","confidence":"high"}
+{"name":"Positionstack","regex":"(?:positionstack).{0,40}\\b([a-zA-Z0-9_]{32})\\b","confidence":"high"}
+{"name":"Postageapp","regex":"(?:postageapp).{0,40}\\b([0-9A-Za-z]{32})\\b","confidence":"high"}
+{"name":"PostgresEnvPostgresDb","regex":"postgres[_-]?env[_-]?postgres[_-]?db(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PostgresEnvPostgresPassword","regex":"postgres[_-]?env[_-]?postgres[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PostgresqlDb","regex":"postgresql[_-]?db(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PostgresqlPass","regex":"postgresql[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Posthog","regex":"\\b(phc_[a-zA-Z0-9_]{43})\\b","confidence":"high"}
+{"name":"Postman","regex":"\\b(PMAK-[a-zA-Z-0-9]{59})\\b","confidence":"high"}
+{"name":"Postmark","regex":"(?:postmark).{0,40}\\b([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b","confidence":"high"}
+{"name":"Powrbot","regex":"(?:powrbot).{0,40}\\b([a-z0-9A-Z]{40})\\b","confidence":"high"}
+{"name":"PrebuildAuth","regex":"prebuild[_-]?auth(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PreferredUsername","regex":"preferred[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PringMailUsername","regex":"pring[_-]?mail[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PrivateKey","regex":"-----(?:(?:BEGIN|END) )(?:(?:EC|PGP|DSA|RSA|OPENSSH).)?PRIVATE.KEY(.BLOCK)?-----","confidence":"low"}
+{"name":"PrivateSigningPassword","regex":"private[_-]?signing[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Privatekey","regex":"-----\\s*?BEGIN[ A-Z0-9_-]*?PRIVATE KEY\\s*?-----[\\s\\S]*?----\\s*?END[ A-Z0-9_-]*? PRIVATE KEY\\s*?-----","confidence":"high"}
+{"name":"ProdAccessKeyId","regex":"prod[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ProdPassword","regex":"prod[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ProdSecretKey","regex":"prod[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ProjectConfig","regex":"project[_-]?config(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Prospectcrm","regex":"(?:prospect).{0,40}\\b([a-z0-9-]{32})\\b","confidence":"high"}
+{"name":"Prospectio","regex":"(?:prospect).{0,40}\\b([a-z0-9A-Z-]{50})\\b","confidence":"high"}
+{"name":"Protocolsio","regex":"(?:protocols).{0,40}\\b([a-z0-9]{64})\\b","confidence":"high"}
+{"name":"Proxycrawl","regex":"(?:proxycrawl).{0,40}\\b([a-zA-Z0-9_]{22})\\b","confidence":"high"}
+{"name":"PublishAccess","regex":"publish[_-]?access(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PublishKey","regex":"publish[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PublishSecret","regex":"publish[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Pubnubpublishkey1","regex":"\\b(sub-c-[0-9a-z]{8}-[a-z]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\\b","confidence":"high"}
+{"name":"Pubnubpublishkey2","regex":"\\b(pub-c-[0-9a-z]{8}-[0-9a-z]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\\b","confidence":"high"}
+{"name":"Purestake","regex":"(?:purestake).{0,40}\\b([a-zA-Z0-9]{40})\\b","confidence":"high"}
+{"name":"Pushbulletapikey","regex":"(?:pushbullet).{0,40}\\b([A-Za-z0-9_\\.]{34})\\b","confidence":"high"}
+{"name":"Pusherchannelkey1","regex":"(?:key).{0,40}\\b([a-z0-9]{20})\\b","confidence":"low"}
+{"name":"Pusherchannelkey2","regex":"(?:pusher).{0,40}\\b([a-z0-9]{20})\\b","confidence":"high"}
+{"name":"Pusherchannelkey3","regex":"(?:pusher).{0,40}\\b([0-9]{7})\\b","confidence":"high"}
+{"name":"PushoverToken","regex":"pushover[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PypiPassowrd","regex":"pypi[_-]?passowrd(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"PypiUploadToken","regex":"pypi-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}","confidence":"high"}
+{"name":"QiitaToken","regex":"qiita[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Qualaroo","regex":"(?:qualaroo).{0,40}\\b([a-z0-9A-Z=]{64})","confidence":"high"}
+{"name":"Qubole","regex":"(?:qubole).{0,40}\\b([0-9a-z]{64})\\b","confidence":"high"}
+{"name":"Quickmetrics","regex":"(?:quickmetrics).{0,40}\\b([a-zA-Z0-9_-]{22})\\b","confidence":"high"}
+{"name":"QuipToken","regex":"quip[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"RabbitmqPassword","regex":"rabbitmq[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Randrmusicapiaccesstoken","regex":"randrmusicapiaccesstoken(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Rapidapi","regex":"(?:rapidapi).{0,40}\\b([A-Za-z0-9_-]{50})\\b","confidence":"high"}
+{"name":"Raven","regex":"(?:raven).{0,40}\\b([A-Z0-9-]{16})\\b","confidence":"high"}
+{"name":"Rawg","regex":"(?:rawg).{0,40}\\b([0-9Aa-z]{32})\\b","confidence":"high"}
+{"name":"Razorpay1","regex":"\\brzp_\\w{2,6}_\\w{10,20}\\b","confidence":"high"}
+{"name":"Readme","regex":"(?:readme).{0,40}\\b([a-zA-Z0-9_]{32})\\b","confidence":"high"}
+{"name":"Reallysimplesystems","regex":"\\b(ey[a-zA-Z0-9-._]{153}.ey[a-zA-Z0-9-._]{916,1000})\\b","confidence":"high"}
+{"name":"Rebrandly","regex":"(?:rebrandly).{0,40}\\b([a-zA-Z0-9_]{32})\\b","confidence":"high"}
+{"name":"RedisStunnelUrls","regex":"redis[_-]?stunnel[_-]?urls(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"RedisUrl","regex":"(REDIS_URL).+","confidence":"low"}
+{"name":"RediscloudUrl","regex":"rediscloud[_-]?url(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Refiner","regex":"(?:refiner).{0,40}\\b([0-9Aa-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b","confidence":"high"}
+{"name":"RefreshToken","regex":"refresh[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"RegistryPass","regex":"registry[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"RegistrySecure","regex":"registry[_-]?secure(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ReleaseGhToken","regex":"release[_-]?gh[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"ReleaseToken","regex":"release[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Repairshopr1","regex":"(?:repairshopr).{0,40}\\b([a-zA-Z0-9_.!+$#^*]{3,32})\\b","confidence":"high"}
+{"name":"Repairshopr2","regex":"(?:repairshopr).{0,40}\\b([a-zA-Z0-9-]{51})\\b","confidence":"high"}
+{"name":"ReportingWebdavPwd","regex":"reporting[_-]?webdav[_-]?pwd(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ReportingWebdavUrl","regex":"reporting[_-]?webdav[_-]?url(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Repotoken","regex":"repotoken(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"RestApiKey","regex":"rest[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Restpack","regex":"(?:restpack).{0,40}\\b([a-zA-Z0-9]{48})\\b","confidence":"high"}
+{"name":"Restpackhtmltopdfapi","regex":"(?:restpack).{0,40}\\b([0-9A-Za-z]{48})\\b","confidence":"high"}
+{"name":"Rev1","regex":"(?:rev).{0,40}\\b([0-9a-zA-Z\\\/\\+]{27}\\=[ \\r\\n]{1})","confidence":"high"}
+{"name":"Rev2","regex":"(?:rev).{0,40}\\b([0-9a-zA-Z\\-]{27}[ \\r\\n]{1})","confidence":"low"}
+{"name":"Revampcrm1","regex":"(?:revamp).{0,40}\\b([a-zA-Z0-9]{40}\\b)","confidence":"high"}
+{"name":"Revampcrm2","regex":"(?:revamp).{0,40}\\b([a-zA-Z0-9.-@]{25,30})\\b","confidence":"low"}
+{"name":"Ringcentral1","regex":"(?:ringcentral).{0,40}\\b(https:\/\/www.[0-9A-Za-z_-]{1,}.com)\\b","confidence":"high"}
+{"name":"Ringcentral2","regex":"(?:ringcentral).{0,40}\\b([0-9A-Za-z_-]{22})\\b","confidence":"high"}
+{"name":"RinkebyPrivateKey","regex":"rinkeby[_-]?private[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Ritekit","regex":"(?:ritekit).{0,40}\\b([0-9a-f]{44})\\b","confidence":"high"}
+{"name":"Rkcs8","regex":"-----BEGIN PRIVATE KEY-----","confidence":"high"}
+{"name":"Roaring","regex":"(?:roaring).{0,40}\\b([0-9A-Za-z_-]{28})\\b","confidence":"high"}
+{"name":"Rocketreach","regex":"(?:rocketreach).{0,50}\\b([a-z0-9-]{30,50})\\b","confidence":"high"}
+{"name":"Roninapp1","regex":"(?:ronin).{0,40}\\b([0-9Aa-zA-Z]{3,32})\\b","confidence":"low"}
+{"name":"Roninapp2","regex":"(?:ronin).{0,40}\\b([0-9a-zA-Z]{26})\\b","confidence":"high"}
+{"name":"RopstenPrivateKey","regex":"ropsten[_-]?private[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Route4Me","regex":"(?:route4me).{0,40}\\b([0-9A-Z]{32})\\b","confidence":"high"}
+{"name":"Route53AccessKeyId","regex":"route53[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Rownd1","regex":"(?:rownd).{0,40}\\b([a-z0-9]{8}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{12})\\b","confidence":"high"}
+{"name":"Rownd2","regex":"(?:rownd).{0,40}\\b([a-z0-9]{48})\\b","confidence":"high"}
+{"name":"Rownd3","regex":"(?:rownd).{0,40}\\b([0-9]{18})\\b","confidence":"high"}
+{"name":"RsaPrivateKey","regex":"-----BEGIN RSA PRIVATE KEY-----","confidence":"high"}
+{"name":"RtdKeyPass","regex":"rtd[_-]?key[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"RtdStorePass","regex":"rtd[_-]?store[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Rubygems","regex":"\\b(rubygems_[a-zA0-9]{48})\\b","confidence":"high"}
+{"name":"RubygemsAuthToken","regex":"rubygems[_-]?auth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Runrunit1","regex":"(?:runrunit).{0,40}\\b([0-9a-f]{32})\\b","confidence":"high"}
+{"name":"Runrunit2","regex":"(?:runrunit).{0,40}\\b([0-9A-Za-z]{18,20})\\b","confidence":"high"}
+{"name":"S3AccessKey","regex":"s3[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"S3AccessKeyId","regex":"s3[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"S3BucketNameAppLogs","regex":"s3[_-]?bucket[_-]?name[_-]?app[_-]?logs(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"S3BucketNameAssets","regex":"s3[_-]?bucket[_-]?name[_-]?assets(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"S3External3AmazonawsCom","regex":"s3[_-]?external[_-]?3[_-]?amazonaws[_-]?com(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"S3Key","regex":"s3[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"S3KeyAppLogs","regex":"s3[_-]?key[_-]?app[_-]?logs(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"S3KeyAssets","regex":"s3[_-]?key[_-]?assets(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"S3SecretAppLogs","regex":"s3[_-]?secret[_-]?app[_-]?logs(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"S3SecretAssets","regex":"s3[_-]?secret[_-]?assets(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"S3SecretKey","regex":"s3[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"S3UserSecret","regex":"s3[_-]?user[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SacloudAccessToken","regex":"sacloud[_-]?access[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SacloudAccessTokenSecret","regex":"sacloud[_-]?access[_-]?token[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SacloudApi","regex":"sacloud[_-]?api(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Salesblink","regex":"(?:salesblink).{0,40}\\b([a-zA-Z]{16})\\b","confidence":"high"}
+{"name":"Salescookie","regex":"(?:salescookie).{0,40}\\b([a-zA-z0-9]{32})\\b","confidence":"high"}
+{"name":"Salesflare","regex":"(?:salesflare).{0,40}\\b([a-zA-Z0-9_]{45})\\b","confidence":"high"}
+{"name":"SalesforceBulkTestPassword","regex":"salesforce[_-]?bulk[_-]?test[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SalesforceBulkTestSecurityToken","regex":"salesforce[_-]?bulk[_-]?test[_-]?security[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SandboxAccessToken","regex":"sandbox[_-]?access[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SandboxAwsAccessKeyId","regex":"sandbox[_-]?aws[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SandboxAwsSecretAccessKey","regex":"sandbox[_-]?aws[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Satismeterprojectkey1","regex":"(?:satismeter).{0,40}\\b([a-zA-Z0-9]{4,20}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,12})\\b","confidence":"high"}
+{"name":"Satismeterprojectkey2","regex":"(?:satismeter).{0,40}\\b([a-zA-Z0-9]{24})\\b","confidence":"high"}
+{"name":"Satismeterprojectkey3","regex":"(?:satismeter).{0,40}\\b([a-zA-Z0-9!=@#$%^]{6,32})","confidence":"high"}
+{"name":"Satismeterwritekey","regex":"(?:satismeter).{0,40}\\b([a-z0-9A-Z]{16})\\b","confidence":"high"}
+{"name":"SauceAccessKey","regex":"sauce[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SauceToken","regex":"(sauce.{0,50}(\"|')?[0-9a-f-]{36}(\"|')?)","confidence":"low"}
+{"name":"Saucelabs1","regex":"\\b(oauth\\-[a-z0-9]{8,}\\-[a-z0-9]{5})\\b","confidence":"high"}
+{"name":"Saucelabs2","regex":"(?:saucelabs).{0,40}\\b([a-z0-9]{8}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{4}\\-[a-z0-9]{12})\\b","confidence":"high"}
+{"name":"Scalewaykey","regex":"(?:scaleway).{0,40}\\b([0-9a-z]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b","confidence":"high"}
+{"name":"Scrapeowl","regex":"(?:scrapeowl).{0,40}\\b([0-9a-z]{30})\\b","confidence":"high"}
+{"name":"Scraperapi","regex":"(?:scraperapi).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Scraperbox","regex":"(?:scraperbox).{0,40}\\b([A-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Scrapersite","regex":"(?:scrapersite).{0,40}\\b([a-zA-Z0-9]{45})\\b","confidence":"high"}
+{"name":"Scrapestack","regex":"(?:scrapestack).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Scrapfly","regex":"(?:scrapfly).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Scrapingant","regex":"(?:scrapingant).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Scrapingbee","regex":"(?:scrapingbee).{0,40}\\b([A-Z0-9]{80})\\b","confidence":"high"}
+{"name":"Screenshotapi","regex":"(?:screenshotapi).{0,40}\\b([0-9A-Z]{7}\\-[0-9A-Z]{7}\\-[0-9A-Z]{7}\\-[0-9A-Z]{7})\\b","confidence":"high"}
+{"name":"Screenshotlayer","regex":"(?:screenshotlayer).{0,40}\\b([a-zA-Z0-9_]{32})\\b","confidence":"high"}
+{"name":"ScrutinizerToken","regex":"scrutinizer[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SdrToken","regex":"sdr[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secret0","regex":"secret[_-]?0(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secret1","regex":"secret[_-]?1(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secret10","regex":"secret[_-]?10(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secret11","regex":"secret[_-]?11(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secret2","regex":"secret[_-]?2(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secret3","regex":"secret[_-]?3(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secret4","regex":"secret[_-]?4(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secret5","regex":"secret[_-]?5(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secret6","regex":"secret[_-]?6(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secret7","regex":"secret[_-]?7(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secret8","regex":"secret[_-]?8(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secret9","regex":"secret[_-]?9(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SecretKeyBase","regex":"secret[_-]?key[_-]?base(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secretaccesskey","regex":"secretaccesskey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Secretkey","regex":"secretkey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Securitytrails","regex":"(?:securitytrails).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"SegmentApiKey","regex":"segment[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Segmentapikey","regex":"(?:segment).{0,40}\\b([A-Za-z0-9_\\-a-zA-Z]{43}\\.[A-Za-z0-9_\\-a-zA-Z]{43})\\b","confidence":"high"}
+{"name":"Selectpdf","regex":"(?:selectpdf).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"SelionLogLevelDev","regex":"selion[_-]?log[_-]?level[_-]?dev(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SelionSeleniumHost","regex":"selion[_-]?selenium[_-]?host(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Semaphore","regex":"(?:semaphore).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Sendbird1","regex":"(?:sendbird).{0,40}\\b([0-9a-f]{40})\\b","confidence":"high"}
+{"name":"Sendbird2","regex":"(?:sendbird).{0,40}\\b([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})\\b","confidence":"high"}
+{"name":"Sendbirdorganizationapi","regex":"(?:sendbird).{0,40}\\b([0-9a-f]{24})\\b","confidence":"high"}
+{"name":"Sendgrid","regex":"(?:sendgrid).{0,40}(SG\\.[\\w\\-_]{20,24}\\.[\\w\\-_]{39,50})\\b","confidence":"high"}
+{"name":"Sendgrid2","regex":"sendgrid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SendgridApiKey","regex":"SG\\.[\\w_]{16,32}\\.[\\w_]{16,64}","confidence":"high"}
+{"name":"SendgridApiKey1","regex":"sendgrid[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SendgridKey","regex":"sendgrid[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SendgridPassword","regex":"sendgrid[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SendgridUser","regex":"sendgrid[_-]?user(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SendgridUsername","regex":"sendgrid[_-]?username(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Sendinbluev2","regex":"\\b(xkeysib\\-[A-Za-z0-9_-]{81})\\b","confidence":"high"}
+{"name":"SendwithusKey","regex":"sendwithus[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Sentiment1","regex":"(?:sentiment).{0,40}\\b([0-9]{17})\\b","confidence":"high"}
+{"name":"Sentiment2","regex":"(?:sentiment).{0,40}\\b([a-zA-Z0-9]{20})\\b","confidence":"high"}
+{"name":"SentryAuthToken","regex":"sentry[_-]?auth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SentryDefaultOrg","regex":"sentry[_-]?default[_-]?org(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SentryEndpoint","regex":"sentry[_-]?endpoint(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SentryKey","regex":"sentry[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Sentrytoken","regex":"(?:sentry).{0,40}\\b([a-f0-9]{64})\\b","confidence":"high"}
+{"name":"Serphouse","regex":"(?:serphouse).{0,40}\\b([0-9A-Za-z]{60})\\b","confidence":"high"}
+{"name":"Serpstack","regex":"(?:serpstack).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"ServiceAccountSecret","regex":"service[_-]?account[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SesAccessKey","regex":"ses[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SesSecretKey","regex":"ses[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Setdstaccesskey","regex":"setdstaccesskey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Setdstsecretkey","regex":"setdstsecretkey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Setsecretkey","regex":"setsecretkey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Sheety1","regex":"(?:sheety).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Sheety2","regex":"(?:sheety).{0,40}\\b([0-9a-z]{64})\\b","confidence":"high"}
+{"name":"Sherpadesk","regex":"(?:sherpadesk).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Shipday","regex":"(?:shipday).{0,40}\\b([a-zA-Z0-9.]{11}[a-zA-Z0-9]{20})\\b","confidence":"high"}
+{"name":"Shodankey","regex":"(?:shodan).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"ShopifyAccessToken","regex":"shpat_[a-fA-F0-9]{32}","confidence":"high"}
+{"name":"ShopifyCustomAppAccessToken","regex":"shpca_[a-fA-F0-9]{32}","confidence":"high"}
+{"name":"ShopifyPrivateAppAccessToken","regex":"shppa_[a-fA-F0-9]{32}","confidence":"high"}
+{"name":"ShopifySharedSecret","regex":"shpss_[a-fA-F0-9]{32}","confidence":"high"}
+{"name":"ShoppableServiceAuth","regex":"data-shoppable-auth-token.+","confidence":"low"}
+{"name":"Shortcut","regex":"(?:shortcut).{0,40}\\b([0-9a-f-]{36})\\b","confidence":"high"}
+{"name":"Shotstack","regex":"(?:shotstack).{0,40}\\b([a-zA-Z0-9]{40})\\b","confidence":"high"}
+{"name":"Shutterstock1","regex":"(?:shutterstock).{0,40}\\b([0-9a-zA-Z]{32})\\b","confidence":"low"}
+{"name":"Shutterstock2","regex":"(?:shutterstock).{0,40}\\b([0-9a-zA-Z]{16})\\b","confidence":"low"}
+{"name":"Shutterstockoauth","regex":"(?:shutterstock).{0,40}\\b(v2\/[0-9A-Za-z]{388})\\b","confidence":"high"}
+{"name":"Signalwire1","regex":"\\b([0-9a-z-]{3,64}.signalwire.com)\\b","confidence":"high"}
+{"name":"Signalwire2","regex":"(?:signalwire).{0,40}\\b([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b","confidence":"high"}
+{"name":"Signalwire3","regex":"(?:signalwire).{0,40}\\b([0-9A-Za-z]{50})\\b","confidence":"high"}
+{"name":"Signaturit","regex":"(?:signaturit).{0,40}\\b([0-9A-Za-z]{86})\\b","confidence":"high"}
+{"name":"SigningKey","regex":"signing[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SigningKeyPassword","regex":"signing[_-]?key[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SigningKeySecret","regex":"signing[_-]?key[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SigningKeySid","regex":"signing[_-]?key[_-]?sid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Signupgenius","regex":"(?:signupgenius).{0,40}\\b([0-9A-Za-z]{32})\\b","confidence":"high"}
+{"name":"Sigopt","regex":"(?:sigopt).{0,40}\\b([A-Z0-9]{48})\\b","confidence":"high"}
+{"name":"Simplesat","regex":"(?:simplesat).{0,40}\\b([a-z0-9]{40})","confidence":"high"}
+{"name":"Simplynoted","regex":"(?:simplynoted).{0,40}\\b([a-zA-Z0-9\\S]{340,360})\\b","confidence":"high"}
+{"name":"Simvoly","regex":"(?:simvoly).{0,40}\\b([a-z0-9]{33})\\b","confidence":"high"}
+{"name":"Sinchmessage","regex":"(?:sinch).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Sirv1","regex":"(?:sirv).{0,40}\\b([a-zA-Z0-9\\S]{88})","confidence":"high"}
+{"name":"Sirv2","regex":"(?:sirv).{0,40}\\b([a-zA-Z0-9]{26})\\b","confidence":"high"}
+{"name":"Siteleaf","regex":"(?:siteleaf).{0,40}\\b([0-9Aa-z]{32})\\b","confidence":"high"}
+{"name":"Skrappio","regex":"(?:skrapp).{0,40}\\b([a-z0-9A-Z]{42})\\b","confidence":"high"}
+{"name":"Skybiometry","regex":"(?:skybiometry).{0,40}\\b([0-9a-z]{25,26})\\b","confidence":"high"}
+{"name":"Slack","regex":"xox[baprs]-[0-9a-zA-Z]{10,48}","confidence":"high"}
+{"name":"SlackAccessToken","regex":"xoxb-[0-9A-Za-z\\-]{51}","confidence":"high"}
+{"name":"SlackToken","regex":"(xox[pborsa]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})","confidence":"high"}
+{"name":"SlackUserToken","regex":"xoxp-[0-9A-Za-z\\-]{72}","confidence":"low"}
+{"name":"SlackWebhook","regex":"https:\/\/hooks.slack.com\/services\/T[a-zA-Z0-9_]{8,10}\/B[a-zA-Z0-9_]{8,12}\/[a-zA-Z0-9_]{23,24}","confidence":"high"}
+{"name":"SlackWebhookUrl","regex":"(hooks.slack.com\/services\/T[A-Z0-9]{8}\/B[A-Z0-9]{8}\/[a-zA-Z0-9]{1,})","confidence":"low"}
+{"name":"Slackwebhook","regex":"(https:\\\/\\\/hooks.slack.com\\\/services\\\/[A-Za-z0-9+\\\/]{44,46})","confidence":"high"}
+{"name":"SlashDeveloperSpace","regex":"slash[_-]?developer[_-]?space(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SlashDeveloperSpaceKey","regex":"slash[_-]?developer[_-]?space[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SlateUserEmail","regex":"slate[_-]?user[_-]?email(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Smartsheets","regex":"(?:smartsheets).{0,40}\\b([a-zA-Z0-9]{37})\\b","confidence":"high"}
+{"name":"Smartystreets1","regex":"(?:smartystreets).{0,40}\\b([a-zA-Z0-9]{20})\\b","confidence":"high"}
+{"name":"Smartystreets2","regex":"(?:smartystreets).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"Smooch1","regex":"(?:smooch).{0,40}\\b(act_[0-9a-z]{24})\\b","confidence":"high"}
+{"name":"Smooch2","regex":"(?:smooch).{0,40}\\b([0-9a-zA-Z_-]{86})\\b","confidence":"high"}
+{"name":"Snipcart","regex":"(?:snipcart).{0,40}\\b([0-9A-Za-z_]{75})\\b","confidence":"high"}
+{"name":"SnoowrapClientSecret","regex":"snoowrap[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SnoowrapPassword","regex":"snoowrap[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SnoowrapRefreshToken","regex":"snoowrap[_-]?refresh[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SnykApiToken","regex":"snyk[_-]?api[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SnykToken","regex":"snyk[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Snykkey","regex":"(?:snyk).{0,40}\\b([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\\b","confidence":"high"}
+{"name":"SocrataAppToken","regex":"socrata[_-]?app[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SocrataPassword","regex":"socrata[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SonarOrganizationKey","regex":"sonar[_-]?organization[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SonarProjectKey","regex":"sonar[_-]?project[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SonarToken","regex":"sonar[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SonarqubeDocsApiKey","regex":"(sonar.{0,50}(\"|')?[0-9a-f]{40}(\"|')?)","confidence":"low"}
+{"name":"SonarqubeToken","regex":"sonar.{0,50}(?:\"|'|`)?[0-9a-f]{40}(?:\"|'|`)?","confidence":"high"}
+{"name":"SonatypeGpgKeyName","regex":"sonatype[_-]?gpg[_-]?key[_-]?name(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SonatypeGpgPassphrase","regex":"sonatype[_-]?gpg[_-]?passphrase(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SonatypeNexusPassword","regex":"sonatype[_-]?nexus[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SonatypePass","regex":"sonatype[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SonatypePassword","regex":"sonatype[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SonatypeTokenPassword","regex":"sonatype[_-]?token[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SonatypeTokenUser","regex":"sonatype[_-]?token[_-]?user(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Sonatypepassword","regex":"sonatypepassword(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SoundcloudClientSecret","regex":"soundcloud[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SoundcloudPassword","regex":"soundcloud[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SpacesAccessKeyId","regex":"spaces[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SpacesSecretAccessKey","regex":"spaces[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Splunkobservabilitytoken","regex":"(?:splunk).{0,40}\\b([a-z0-9A-Z]{22})\\b","confidence":"high"}
+{"name":"Spoonacular","regex":"(?:spoonacular).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Sportsmonk","regex":"(?:sportsmonk).{0,40}\\b([0-9a-zA-Z]{60})\\b","confidence":"high"}
+{"name":"SpotifyApiAccessToken","regex":"spotify[_-]?api[_-]?access[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SpotifyApiClientSecret","regex":"spotify[_-]?api[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SpringMailPassword","regex":"spring[_-]?mail[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Sqsaccesskey","regex":"sqsaccesskey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Sqssecretkey","regex":"sqssecretkey(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Square","regex":"(?:square).{0,40}(EAAA[a-zA-Z0-9\\-\\+\\=]{60})","confidence":"high"}
+{"name":"SquareAccessToken","regex":"sq0atp-[0-9A-Za-z\\-_]{22}","confidence":"high"}
+{"name":"SquareApiKey","regex":"sq0(atp|csp)-[0-9a-z-_]{22,43}","confidence":"low"}
+{"name":"SquareAppSecret","regex":"(sq0[a-z]{3}-[0-9A-Za-z-_]{20,50})","confidence":"low"}
+{"name":"SquareOauthSecret","regex":"sq0csp-[0-9A-Za-z\\-_]{43}","confidence":"high"}
+{"name":"SquareReaderSdkRepositoryPassword","regex":"square[_-]?reader[_-]?sdk[_-]?repository[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Squareapp1","regex":"[\\w\\-]*sq0i[a-z]{2}-[0-9A-Za-z\\-_]{22,43}","confidence":"high"}
+{"name":"Squareapp2","regex":"[\\w\\-]*sq0c[a-z]{2}-[0-9A-Za-z\\-_]{40,50}","confidence":"high"}
+{"name":"Squarespace","regex":"(?:squarespace).{0,40}\\b([0-9Aa-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b","confidence":"high"}
+{"name":"Squareup","regex":"\\b(sq0idp-[0-9A-Za-z]{22})\\b","confidence":"high"}
+{"name":"SrcclrApiToken","regex":"srcclr[_-]?api[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Ssh","regex":"-----BEGIN OPENSSH PRIVATE KEY-----","confidence":"high"}
+{"name":"SshDsaPrivateKey","regex":"-----BEGIN DSA PRIVATE KEY-----","confidence":"high"}
+{"name":"SshPassword","regex":"(sshpass -p.*['|\"])","confidence":"low"}
+{"name":"Sshpass","regex":"sshpass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Sslmate","regex":"(?:sslmate).{0,40}\\b([a-zA-Z0-9]{36})\\b","confidence":"high"}
+{"name":"SsmtpConfig","regex":"ssmtp[_-]?config(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"StagingBaseUrlRunscope","regex":"staging[_-]?base[_-]?url[_-]?runscope(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"StarTestAwsAccessKeyId","regex":"star[_-]?test[_-]?aws[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"StarTestBucket","regex":"star[_-]?test[_-]?bucket(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"StarTestLocation","regex":"star[_-]?test[_-]?location(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"StarTestSecretAccessKey","regex":"star[_-]?test[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"StarshipAccountSid","regex":"starship[_-]?account[_-]?sid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"StarshipAuthToken","regex":"starship[_-]?auth[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Stitchdata","regex":"(?:stitchdata).{0,40}\\b([0-9a-z_]{35})\\b","confidence":"high"}
+{"name":"Stockdata","regex":"(?:stockdata).{0,40}\\b([0-9A-Za-z]{40})\\b","confidence":"high"}
+{"name":"Storecove","regex":"(?:storecove).{0,40}\\b([a-zA-Z0-9_-]{43})\\b","confidence":"high"}
+{"name":"Stormglass","regex":"(?:stormglass).{0,40}\\b([0-9Aa-z-]{73})\\b","confidence":"high"}
+{"name":"StormpathApiKeyId","regex":"stormpath[_-]?api[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"StormpathApiKeySecret","regex":"stormpath[_-]?api[_-]?key[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Storyblok","regex":"(?:storyblok).{0,40}\\b([0-9A-Za-z]{22}t{2})\\b","confidence":"high"}
+{"name":"Storychief","regex":"(?:storychief).{0,40}\\b([a-zA-Z0-9_\\-.]{940,1000})","confidence":"high"}
+{"name":"Strava1","regex":"(?:strava).{0,40}\\b([0-9]{5})\\b","confidence":"high"}
+{"name":"Strava2","regex":"(?:strava).{0,40}\\b([0-9a-z]{40})\\b","confidence":"high"}
+{"name":"Streak","regex":"(?:streak).{0,40}\\b([0-9Aa-f]{32})\\b","confidence":"high"}
+{"name":"StripPublishableKey","regex":"strip[_-]?publishable[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"StripSecretKey","regex":"strip[_-]?secret[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Stripe","regex":"[rs]k_live_[a-zA-Z0-9]{20,30}","confidence":"high"}
+{"name":"StripeApiKey1","regex":"sk_live_[0-9a-zA-Z]{24}","confidence":"high"}
+{"name":"StripeApiKey2","regex":"stripe[sr]k_live_[0-9a-zA-Z]{24}","confidence":"high"}
+{"name":"StripeApiKey3","regex":"stripe[sk|rk]_live_[0-9a-zA-Z]{24}","confidence":"high"}
+{"name":"StripePrivate","regex":"stripe[_-]?private(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"StripePublic","regex":"stripe[_-]?public(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"StripePublicLiveKey","regex":"pk_live_[0-9a-z]{24}","confidence":"high"}
+{"name":"StripePublicTestKey","regex":"pk_test_[0-9a-z]{24}","confidence":"high"}
+{"name":"StripeRestricedKey","regex":"rk_(?:live|test)_[0-9a-zA-Z]{24}","confidence":"high"}
+{"name":"StripeRestrictedApi","regex":"(rk_live_[0-9a-zA-Z]{24,34})","confidence":"low"}
+{"name":"StripeRestrictedApiKey","regex":"rk_live_[0-9a-zA-Z]{24}","confidence":"high"}
+{"name":"StripeSecretKey","regex":"sk_(?:live|test)_[0-9a-zA-Z]{24}","confidence":"high"}
+{"name":"StripeSecretLiveKey","regex":"(sk|rk)_live_[0-9a-z]{24}","confidence":"high"}
+{"name":"StripeSecretTestKey","regex":"(sk|rk)_test_[0-9a-z]{24}","confidence":"high"}
+{"name":"StripeStandardApi","regex":"(sk_live_[0-9a-zA-Z]{24,34})","confidence":"low"}
+{"name":"Stytch1","regex":"(?:stytch).{0,40}\\b([a-zA-Z0-9-_]{47}=)","confidence":"high"}
+{"name":"Stytch2","regex":"(?:stytch).{0,40}\\b([a-z0-9-]{49})\\b","confidence":"high"}
+{"name":"Sugester1","regex":"(?:sugester).{0,40}\\b([a-zA-Z0-9_.!+$#^*%]{3,32})\\b","confidence":"high"}
+{"name":"Sugester2","regex":"(?:sugester).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Sumologickey1","regex":"(?:sumo).{0,40}\\b([A-Za-z0-9]{14})\\b","confidence":"high"}
+{"name":"Sumologickey2","regex":"(?:sumo).{0,40}\\b([A-Za-z0-9]{64})\\b","confidence":"high"}
+{"name":"Supernotesapi","regex":"(?:supernotes).{0,40}([ \\r\\n]{0,1}[0-9A-Za-z\\-_]{43}[ \\r\\n]{1})","confidence":"high"}
+{"name":"SurgeLogin","regex":"surge[_-]?login(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"SurgeToken","regex":"surge[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Surveyanyplace1","regex":"(?:survey).{0,40}\\b([a-z0-9A-Z-]{36})\\b","confidence":"low"}
+{"name":"Surveyanyplace2","regex":"(?:survey).{0,40}\\b([a-z0-9A-Z]{32})\\b","confidence":"low"}
+{"name":"Surveybot","regex":"(?:surveybot).{0,40}\\b([A-Za-z0-9-]{80})\\b","confidence":"high"}
+{"name":"Surveysparrow","regex":"(?:surveysparrow).{0,40}\\b([a-zA-Z0-9-_]{88})\\b","confidence":"high"}
+{"name":"Survicate","regex":"(?:survicate).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"SvnPass","regex":"svn[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Swell1","regex":"(?:swell).{0,40}\\b([a-zA-Z0-9]{6,24})\\b","confidence":"low"}
+{"name":"Swell2","regex":"(?:swell).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Swiftype","regex":"(?:swiftype).{0,40}\\b([a-zA-z-0-9]{6}\\_[a-zA-z-0-9]{6}\\-[a-zA-z-0-9]{6})\\b","confidence":"high"}
+{"name":"Tallyfy","regex":"(?:tallyfy).{0,40}\\b([0-9A-Za-z]{36}\\.[0-9A-Za-z]{264}\\.[0-9A-Za-z\\-\\_]{683})\\b","confidence":"high"}
+{"name":"Tatumio","regex":"(?:tatum).{0,40}\\b([0-9a-z-]{36})\\b","confidence":"high"}
+{"name":"Taxjar","regex":"(?:taxjar).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Teamgate1","regex":"(?:teamgate).{0,40}\\b([a-z0-9]{40})\\b","confidence":"high"}
+{"name":"Teamgate2","regex":"(?:teamgate).{0,40}\\b([a-zA-Z0-9]{80})\\b","confidence":"high"}
+{"name":"Teamworkcrm","regex":"(?:teamwork|teamworkcrm).{0,40}\\b(tkn\\.v1_[0-9A-Za-z]{71}=[ \\r\\n]{1})","confidence":"high"}
+{"name":"Teamworkdesk","regex":"(?:teamwork|teamworkdesk).{0,40}\\b(tkn\\.v1_[0-9A-Za-z]{71}=[ \\r\\n]{1})","confidence":"high"}
+{"name":"Teamworkspaces","regex":"(?:teamwork|teamworkspaces).{0,40}\\b(tkn\\.v1_[0-9A-Za-z]{71}=[ \\r\\n]{1})","confidence":"high"}
+{"name":"Technicalanalysisapi","regex":"(?:technicalanalysisapi).{0,40}\\b([A-Z0-9]{48})\\b","confidence":"high"}
+{"name":"TelegramBotApiKey","regex":"[0-9]+:AA[0-9A-Za-z\\-_]{33}","confidence":"high"}
+{"name":"TelegramSecret","regex":"d{5,}:A[0-9a-z_-]{34,34}","confidence":"high"}
+{"name":"Telegrambottoken","regex":"(?:telegram).{0,40}\\b([0-9]{8,10}:[a-zA-Z0-9_-]{35})\\b","confidence":"high"}
+{"name":"Telnyx","regex":"(?:telnyx).{0,40}\\b(KEY[0-9A-Za-z_-]{55})\\b","confidence":"high"}
+{"name":"Terraformcloudpersonaltoken","regex":"\\b([A-Za-z0-9]{14}.atlasv1.[A-Za-z0-9]{67})\\b","confidence":"high"}
+{"name":"TescoApiKey","regex":"tesco[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TestGithubToken","regex":"test[_-]?github[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TestTest","regex":"test[_-]?test(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TesterKeysPassword","regex":"tester[_-]?keys[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Text2Data","regex":"(?:text2data).{0,40}\\b([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})\\b","confidence":"high"}
+{"name":"Textmagic1","regex":"(?:textmagic).{0,40}\\b([0-9A-Za-z]{30})\\b","confidence":"high"}
+{"name":"Textmagic2","regex":"(?:textmagic).{0,40}\\b([0-9A-Za-z]{1,25})\\b","confidence":"high"}
+{"name":"Theoddsapi","regex":"(?:theoddsapi|the-odds-api).{0,40}\\b([0-9a-f]{32})\\b","confidence":"high"}
+{"name":"TheraOssAccessKey","regex":"thera[_-]?oss[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Thinkific1","regex":"(?:thinkific).{0,40}\\b([0-9a-f]{32})\\b","confidence":"high"}
+{"name":"Thinkific2","regex":"(?:thinkific).{0,40}\\b([0-9A-Za-z]{4,40})\\b","confidence":"high"}
+{"name":"Thousandeyes1","regex":"(?:thousandeyes).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Thousandeyes2","regex":"(?:thousandeyes).{0,40}\\b([a-zA-Z0-9]{3,20}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,5})\\b","confidence":"high"}
+{"name":"Ticketmaster","regex":"(?:ticketmaster).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Tiingo","regex":"(?:tiingo).{0,40}\\b([0-9a-z]{40})\\b","confidence":"high"}
+{"name":"Timezoneapi","regex":"(?:timezoneapi).{0,40}\\b([a-zA-Z0-9]{20})\\b","confidence":"high"}
+{"name":"Tly","regex":"(?:tly).{0,40}\\b([0-9A-Za-z]{60})\\b","confidence":"high"}
+{"name":"Tmetric","regex":"(?:tmetric).{0,40}\\b([0-9A-Z]{64})\\b","confidence":"high"}
+{"name":"Todoist","regex":"(?:todoist).{0,40}\\b([0-9a-z]{40})\\b","confidence":"high"}
+{"name":"Toggltrack","regex":"(?:toggl).{0,40}\\b([0-9Aa-z]{32})\\b","confidence":"high"}
+{"name":"TokenCoreJava","regex":"token[_-]?core[_-]?java(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Tomorrowio","regex":"(?:tomorrow).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Tomtom","regex":"(?:tomtom).{0,40}\\b([0-9Aa-zA-Z]{32})\\b","confidence":"high"}
+{"name":"Tradier","regex":"(?:tradier).{0,40}\\b([a-zA-Z0-9]{28})\\b","confidence":"high"}
+{"name":"Travelpayouts","regex":"(?:travelpayouts).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"TravisAccessToken","regex":"travis[_-]?access[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TravisApiToken","regex":"travis[_-]?api[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TravisBranch","regex":"travis[_-]?branch(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TravisComToken","regex":"travis[_-]?com[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TravisE2EToken","regex":"travis[_-]?e2e[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TravisGhToken","regex":"travis[_-]?gh[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TravisPullRequest","regex":"travis[_-]?pull[_-]?request(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TravisSecureEnvVars","regex":"travis[_-]?secure[_-]?env[_-]?vars(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"TravisToken","regex":"travis[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Travisci","regex":"(?:travis).{0,40}\\b([a-zA-Z0-9A-Z_]{22})\\b","confidence":"high"}
+{"name":"TrelloUrl","regex":"https:\/\/trello.com\/b\/[0-9a-z]\/[0-9a-z_-]+","confidence":"high"}
+{"name":"Trelloapikey2","regex":"(?:trello).{0,40}\\b([a-zA-Z-0-9]{32})\\b","confidence":"high"}
+{"name":"TrexClientToken","regex":"trex[_-]?client[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TrexOktaClientToken","regex":"trex[_-]?okta[_-]?client[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Twelvedata","regex":"(?:twelvedata).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Twilio1","regex":"\\bAC[0-9a-f]{32}\\b","confidence":"high"}
+{"name":"TwilioApiKey","regex":"twilio[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"TwilioApiSecret","regex":"twilio[_-]?api[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"TwilioChatAccountApiService","regex":"twilio[_-]?chat[_-]?account[_-]?api[_-]?service(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"TwilioConfigurationSid","regex":"twilio[_-]?configuration[_-]?sid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TwilioSid","regex":"twilio[_-]?sid(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TwilioToken","regex":"twilio[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"TwinePassword","regex":"twine[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"TwitterAccessToken","regex":"[tT][wW][iI][tT][tT][eE][rR].*[1-9][0-9]+-[0-9a-zA-Z]{40}","confidence":"low"}
+{"name":"TwitterClientId","regex":"twitter[0-9a-z]{18,25}","confidence":"high"}
+{"name":"TwitterConsumerKey","regex":"twitter[_-]?consumer[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"TwitterConsumerSecret","regex":"twitter[_-]?consumer[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"TwitterOauth","regex":"[tT][wW][iI][tT][tT][eE][rR].*['|\"][0-9a-zA-Z]{35,44}['|\"]","confidence":"low"}
+{"name":"TwitterSecretKey","regex":"twitter[0-9a-z]{35,44}","confidence":"high"}
+{"name":"Twitteroauthaccesssecret","regex":"twitteroauthaccesssecret(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Twitteroauthaccesstoken","regex":"twitteroauthaccesstoken(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"Tyntec","regex":"(?:tyntec).{0,40}\\b([a-zA-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Typeform","regex":"(?:typeform).{0,40}\\b([0-9A-Za-z]{44})\\b","confidence":"high"}
+{"name":"Ubidots","regex":"\\b(BBFF-[0-9a-zA-Z]{30})\\b","confidence":"high"}
+{"name":"Unifyid","regex":"(?:unify).{0,40}\\b([0-9A-Za-z_=-]{44})","confidence":"high"}
+{"name":"UnityPassword","regex":"unity[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"UnitySerial","regex":"unity[_-]?serial(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Unplugg","regex":"(?:unplu).{0,40}\\b([a-z0-9]{64})\\b","confidence":"high"}
+{"name":"Unsplash","regex":"(?:unsplash).{0,40}\\b([0-9A-Za-z_]{43})\\b","confidence":"high"}
+{"name":"Upcdatabase","regex":"(?:upcdatabase).{0,40}\\b([A-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Uplead","regex":"(?:uplead).{0,40}\\b([a-z0-9-]{32})\\b","confidence":"high"}
+{"name":"Uploadcare","regex":"(?:uploadcare).{0,40}\\b([a-z0-9]{20})\\b","confidence":"high"}
+{"name":"Upwave","regex":"(?:upwave).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"UrbanKey","regex":"urban[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"UrbanMasterSecret","regex":"urban[_-]?master[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"UrbanSecret","regex":"urban[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Uri","regex":"\\b[a-zA-Z]{1,10}:?\\\/\\\/[-.%\\w{}]{1,50}:([-.%\\S]{3,50})@[-.%\\w\\\/:]+\\b","confidence":"low"}
+{"name":"Urlscan","regex":"(?:urlscan).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"UsEast1ElbAmazonawsCom","regex":"us[_-]?east[_-]?1[_-]?elb[_-]?amazonaws[_-]?com(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"UseSsh","regex":"use[_-]?ssh(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"UserAssetsAccessKeyId","regex":"user[_-]?assets[_-]?access[_-]?key[_-]?id(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"UserAssetsSecretAccessKey","regex":"user[_-]?assets[_-]?secret[_-]?access[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Userstack","regex":"(?:userstack).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Usertravis","regex":"usertravis(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"VSfdcClientSecret","regex":"v[_-]?sfdc[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"VSfdcPassword","regex":"v[_-]?sfdc[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Vatlayer","regex":"(?:vatlayer).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"Vercel","regex":"(?:vercel).{0,40}\\b([a-zA-Z0-9]{24})\\b","confidence":"high"}
+{"name":"Verifier1","regex":"(?:verifier).{0,40}\\b([a-zA-Z-0-9-]{5,16}\\@[a-zA-Z-0-9]{4,16}\\.[a-zA-Z-0-9]{3,6})\\b","confidence":"high"}
+{"name":"Verifier2","regex":"(?:verifier).{0,40}\\b([a-z0-9]{96})\\b","confidence":"high"}
+{"name":"Verimail","regex":"(?:verimail).{0,40}\\b([A-Z0-9]{32})\\b","confidence":"high"}
+{"name":"Veriphone","regex":"(?:veriphone).{0,40}\\b([0-9A-Z]{32})\\b","confidence":"high"}
+{"name":"Versioneye","regex":"(?:versioneye).{0,40}\\b([a-zA-Z0-9-]{40})\\b","confidence":"high"}
+{"name":"Viewneo","regex":"(?:viewneo).{0,40}\\b([a-z0-9A-Z]{120,300}.[a-z0-9A-Z]{150,300}.[a-z0-9A-Z-_]{600,800})","confidence":"high"}
+{"name":"VipGithubBuildRepoDeployKey","regex":"vip[_-]?github[_-]?build[_-]?repo[_-]?deploy[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"VipGithubDeployKey","regex":"vip[_-]?github[_-]?deploy[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"VipGithubDeployKeyPass","regex":"vip[_-]?github[_-]?deploy[_-]?key[_-]?pass(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Virustotal","regex":"(?:virustotal).{0,40}\\b([a-f0-9]{64})\\b","confidence":"high"}
+{"name":"VirustotalApikey","regex":"virustotal[_-]?apikey(=| =|:| :)\\s*([^\\s]+)","confidence":"high"}
+{"name":"VisualRecognitionApiKey","regex":"visual[_-]?recognition[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Visualcrossing","regex":"(?:visualcrossing).{0,40}\\b([0-9A-Z]{25})\\b","confidence":"high"}
+{"name":"Voicegain","regex":"(?:voicegain).{0,40}\\b(ey[0-9a-zA-Z_-]{34}.ey[0-9a-zA-Z_-]{108}.[0-9a-zA-Z_-]{43})\\b","confidence":"high"}
+{"name":"Vouchery1","regex":"(?:vouchery).{0,40}\\b([a-z0-9-]{36})\\b","confidence":"high"}
+{"name":"Vouchery2","regex":"(?:vouchery).{0,40}\\b([a-zA-Z0-9-\\S]{2,20})\\b","confidence":"high"}
+{"name":"Vpnapi","regex":"(?:vpnapi).{0,40}\\b([a-z0-9A-Z]{32})\\b","confidence":"high"}
+{"name":"Vscetoken","regex":"vscetoken(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Vultrapikey","regex":"(?:vultr).{0,40} \\b([A-Z0-9]{36})\\b","confidence":"high"}
+{"name":"Vyte","regex":"(?:vyte).{0,40}\\b([0-9a-z]{50})\\b","confidence":"high"}
+{"name":"WakatimeApiKey","regex":"wakatime[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Walkscore","regex":"(?:walkscore).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"WatsonConversationPassword","regex":"watson[_-]?conversation[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WatsonDevicePassword","regex":"watson[_-]?device[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WatsonPassword","regex":"watson[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Weatherbit","regex":"(?:weatherbit).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Weatherstack","regex":"(?:weatherstack).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Webex1","regex":"(?:error).{0,40}(redirect_uri_mismatch)","confidence":"high"}
+{"name":"Webex2","regex":"(?:webex).{0,40}\\b([A-Za-z0-9_-]{65})\\b","confidence":"high"}
+{"name":"Webex3","regex":"(?:webex).{0,40}\\b([A-Za-z0-9_-]{64})\\b","confidence":"high"}
+{"name":"Webflow","regex":"(?:webflow).{0,40}\\b([a-zA0-9]{64})\\b","confidence":"high"}
+{"name":"Webscraper","regex":"(?:webscraper).{0,40}\\b([a-zA-Z0-9]{60})\\b","confidence":"high"}
+{"name":"Webscraping","regex":"(?:webscraping).{0,40}\\b([0-9A-Za-z]{32})\\b","confidence":"high"}
+{"name":"Wepay2","regex":"(?:wepay).{0,40}\\b([a-zA-Z0-9_?]{62})\\b","confidence":"high"}
+{"name":"Whoxy","regex":"(?:whoxy).{0,40}\\b([0-9a-z]{33})\\b","confidence":"high"}
+{"name":"WidgetBasicPassword","regex":"widget[_-]?basic[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WidgetBasicPassword2","regex":"widget[_-]?basic[_-]?password[_-]?2(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WidgetBasicPassword3","regex":"widget[_-]?basic[_-]?password[_-]?3(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WidgetBasicPassword4","regex":"widget[_-]?basic[_-]?password[_-]?4(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WidgetBasicPassword5","regex":"widget[_-]?basic[_-]?password[_-]?5(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WidgetFbPassword","regex":"widget[_-]?fb[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WidgetFbPassword2","regex":"widget[_-]?fb[_-]?password[_-]?2(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WidgetFbPassword3","regex":"widget[_-]?fb[_-]?password[_-]?3(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WidgetTestServer","regex":"widget[_-]?test[_-]?server(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WincertPassword","regex":"wincert[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WordpressDbPassword","regex":"wordpress[_-]?db[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WordpressDbUser","regex":"wordpress[_-]?db[_-]?user(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Worksnaps","regex":"(?:worksnaps).{0,40}\\b([0-9A-Za-z]{40})\\b","confidence":"high"}
+{"name":"Workstack","regex":"(?:workstack).{0,40}\\b([0-9Aa-zA-Z]{60})\\b","confidence":"high"}
+{"name":"Worldcoinindex","regex":"(?:worldcoinindex).{0,40}\\b([a-zA-Z0-9]{35})\\b","confidence":"high"}
+{"name":"Worldweather","regex":"(?:worldweather).{0,40}\\b([0-9a-z]{31})\\b","confidence":"high"}
+{"name":"WpjmPhpunitGoogleGeocodeApiKey","regex":"wpjm[_-]?phpunit[_-]?google[_-]?geocode[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WporgPassword","regex":"wporg[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WptDbPassword","regex":"wpt[_-]?db[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WptDbUser","regex":"wpt[_-]?db[_-]?user(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WptPrepareDir","regex":"wpt[_-]?prepare[_-]?dir(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WptReportApiKey","regex":"wpt[_-]?report[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WptSshConnect","regex":"wpt[_-]?ssh[_-]?connect(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"WptSshPrivateKeyBase64","regex":"wpt[_-]?ssh[_-]?private[_-]?key[_-]?base64(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Wrike","regex":"(?:wrike).{0,40}\\b(ey[a-zA-Z0-9-._]{333})\\b","confidence":"high"}
+{"name":"WwwGoogleapisCom","regex":"www[_-]?googleapis[_-]?com(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Yandex","regex":"(?:yandex).{0,40}\\b([a-z0-9A-Z.]{83})\\b","confidence":"high"}
+{"name":"YangshunGhPassword","regex":"yangshun[_-]?gh[_-]?password(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"YangshunGhToken","regex":"yangshun[_-]?gh[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Youneedabudget","regex":"(?:youneedabudget).{0,40}\\b([0-9a-f]{64})\\b","confidence":"high"}
+{"name":"Yousign","regex":"(?:yousign).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Youtubeapikey1","regex":"(?:youtube).{0,40}\\b([a-zA-Z-0-9_]{39})\\b","confidence":"low"}
+{"name":"YtAccountClientSecret","regex":"yt[_-]?account[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"YtAccountRefreshToken","regex":"yt[_-]?account[_-]?refresh[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"YtApiKey","regex":"yt[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"YtClientSecret","regex":"yt[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"YtPartnerClientSecret","regex":"yt[_-]?partner[_-]?client[_-]?secret(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"YtPartnerRefreshToken","regex":"yt[_-]?partner[_-]?refresh[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"YtServerApiKey","regex":"yt[_-]?server[_-]?api[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"ZapierWebhook","regex":"https:\/\/(?:www.)?hooks\\.zapier\\.com\/hooks\/catch\/[A-Za-z0-9]+\/[A-Za-z0-9]+\/","confidence":"low"}
+{"name":"Zapierwebhook","regex":"(https:\\\/\\\/hooks.zapier.com\\\/hooks\\\/catch\\\/[A-Za-z0-9\\\/]{16})","confidence":"high"}
+{"name":"ZendeskTravisGithub","regex":"zendesk[_-]?travis[_-]?github(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Zendeskapi3","regex":"(?:zendesk).{0,40}([A-Za-z0-9_-]{40})","confidence":"high"}
+{"name":"Zenkitapi","regex":"(?:zenkit).{0,40}\\b([0-9a-z]{8}\\-[0-9A-Za-z]{32})\\b","confidence":"high"}
+{"name":"Zenscrape","regex":"(?:zenscrape).{0,40}\\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b","confidence":"high"}
+{"name":"Zenserp","regex":"(?:zenserp).{0,40}\\b([0-9a-z-]{36})\\b","confidence":"high"}
+{"name":"Zensonatypepassword","regex":"zensonatypepassword(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Zeplin","regex":"(?:zeplin).{0,40}\\b([a-zA-Z0-9-.]{350,400})\\b","confidence":"high"}
+{"name":"Zerobounce","regex":"(?:zerobounce).{0,40}\\b([a-z0-9]{32})\\b","confidence":"high"}
+{"name":"ZhuliangGhToken","regex":"zhuliang[_-]?gh[_-]?token(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}
+{"name":"Zipapi1","regex":"(?:zipapi).{0,40}\\b([a-zA-Z0-9!=@#$%^]{7,})","confidence":"high"}
+{"name":"Zipapi3","regex":"(?:zipapi).{0,40}\\b([0-9a-z]{32})\\b","confidence":"high"}
+{"name":"Zipcodeapi","regex":"(?:zipcodeapi).{0,40}\\b([a-zA-Z0-9]{64})\\b","confidence":"high"}
+{"name":"ZohoWebhook","regex":"https:\/\/creator\\.zoho\\.com\/api\/[A-Za-z0-9\/\\-_\\.]+\\?authtoken=[A-Za-z0-9]+","confidence":"low"}
+{"name":"Zonkafeedback","regex":"(?:zonka).{0,40}\\b([A-Za-z0-9]{36})\\b","confidence":"high"}
+{"name":"ZopimAccountKey","regex":"zopim[_-]?account[_-]?key(=| =|:| :)\\s*([^\\s]+)","confidence":"low"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dependencies = [
     "presidio-analyzer>=2.2.355",
     "presidio-anonymizer>=2.2.355",
     "instructor>=1.7.0",
+    "numpy<2.0.0",
+    "gibberish-detector>=0.1.1",
+    "detect-secrets>=1.5.0",
+    "hyperscan>=0.7.8"
 ]
 
 [project.optional-dependencies]

--- a/tests/guardrails_genie/guardrails/test_secrets_detection.py
+++ b/tests/guardrails_genie/guardrails/test_secrets_detection.py
@@ -2,15 +2,14 @@ import hashlib
 import re
 
 import pytest
-from hypothesis import given, strategies as st, settings
+from hypothesis import strategies as st, given, settings
 
+from guardrails_genie.guardrails import SecretsDetectionGuardrail
 from guardrails_genie.guardrails.secrets_detection import (
-    DEFAULT_SECRETS_PATTERNS,
     SecretsDetectionSimpleResponse,
     SecretsDetectionResponse,
-    SecretsDetectionGuardrail,
     REDACTION,
-    redact,
+    redact_value,
 )
 
 
@@ -18,7 +17,7 @@ from guardrails_genie.guardrails.secrets_detection import (
 def mock_secrets_guard(monkeypatch):
     def _mock_guard(*args, **kwargs):
         prompt = kwargs.get("prompt")
-        return_detected_types = kwargs.get("return_detected_types")
+        return_detected_types = kwargs.get("return_detected_secrets")
 
         if "safe text" in prompt:
             if return_detected_types:
@@ -27,12 +26,14 @@ def mock_secrets_guard(monkeypatch):
                     explanation="No secrets detected in the text.",
                     detected_secrets={},
                     redacted_text=prompt,
+                    risk_score=0.0,
                 )
             else:
                 return SecretsDetectionSimpleResponse(
                     contains_secrets=False,
                     explanation="No secrets detected in the text.",
                     redacted_text=prompt,
+                    risk_score=0.0,
                 )
         else:
             if return_detected_types:
@@ -41,12 +42,14 @@ def mock_secrets_guard(monkeypatch):
                     explanation="The output contains secrets.",
                     detected_secrets={"secrets": ["API_KEY"]},
                     redacted_text="My secret key is [REDACTED:]************[:REDACTED]",
+                    risk_score=1.0,
                 )
             else:
                 return SecretsDetectionSimpleResponse(
                     contains_secrets=True,
                     explanation="The output contains secrets.",
                     redacted_text="My secret key is [REDACTED:]************[:REDACTED]",
+                    risk_score=1.0,
                 )
 
     monkeypatch.setattr(
@@ -56,32 +59,22 @@ def mock_secrets_guard(monkeypatch):
 
 
 def test_redact_partial():
-    text = "My secret key is ABCDEFGHIJKL"
-    matches = ["ABCDEFGHIJKL"]
-    redacted_text = redact(text, matches, REDACTION.REDACT_PARTIAL)
-    assert redacted_text == "My secret key is [REDACTED:]AB..KL[:REDACTED]"
+    text = "ABCDEFGHIJKL"
+    redacted_text = redact_value(text, REDACTION.REDACT_PARTIAL)
+    assert redacted_text == "[REDACTED:]AB..KL[:REDACTED]"
 
 
 def test_redact_all():
-    text = "My secret key is ABCDEFGHIJKL"
-    matches = ["ABCDEFGHIJKL"]
-    redacted_text = redact(text, matches, REDACTION.REDACT_ALL)
-    assert redacted_text == "My secret key is [REDACTED:]************[:REDACTED]"
+    text = "ABCDEFGHIJKL"
+    redacted_text = redact_value(text, REDACTION.REDACT_ALL)
+    assert redacted_text == "[REDACTED:]************[:REDACTED]"
 
 
 def test_redact_hash():
-    text = "My secret key is ABCDEFGHIJKL"
-    matches = ["ABCDEFGHIJKL"]
-    hashed_value = hashlib.md5("ABCDEFGHIJKL".encode()).hexdigest()
-    redacted_text = redact(text, matches, REDACTION.REDACT_HASH)
-    assert redacted_text == f"My secret key is [REDACTED:]{hashed_value}[:REDACTED]"
-
-
-def test_redact_no_match():
-    text = "My secret key is ABCDEFGHIJKL"
-    matches = ["XYZ"]
-    redacted_text = redact(text, matches, REDACTION.REDACT_ALL)
-    assert redacted_text == text
+    text = "ABCDEFGHIJKL"
+    hashed_value = hashlib.md5(text.encode()).hexdigest()
+    redacted_text = redact_value(text, REDACTION.REDACT_HASH)
+    assert redacted_text == f"[REDACTED:]{hashed_value}[:REDACTED]"
 
 
 def test_secrets_detection_guardrail_detect_types(mock_secrets_guard):
@@ -134,16 +127,15 @@ def test_secrets_detection_guardrail_no_secrets(mock_secrets_guard):
     assert result.redacted_text == prompt
 
 
-# Create a strategy to generate strings that match the patterns
 def pattern_strategy(pattern):
     return st.from_regex(re.compile(pattern), fullmatch=True)
 
 
-@settings(deadline=1000)  # Set the deadline to 1000 milliseconds (1 second)
-@given(pattern_strategy(DEFAULT_SECRETS_PATTERNS["JwtToken"][0]))
+@settings(deadline=1000)
+@given(pattern_strategy(r"AKIA[0-9A-Z]{16}"))
 def test_specific_pattern_guardrail(text):
     guardrail = SecretsDetectionGuardrail(redaction=REDACTION.REDACT_ALL)
     result = guardrail.guard(prompt=text, return_detected_secrets=True)
 
     assert result.contains_secrets is True
-    assert "JwtToken" in result.detected_secrets
+    assert "AWS Access Key" in result.detected_secrets


### PR DESCRIPTION
This pull request includes significant updates to the secrets detection functionality, including new implementations and enhancements to existing methods, as well as updates to dependencies and tests.

### Enhancements to Secrets Detection:

* Added benchmarking script `benchmarks/secrets_benchmark.py` : Introduced `GuardrailsAISecretsDetector` and `LLMGuardSecretsDetector` classes for secrets detection, including methods to scan text and return detailed responses. Evaluates and compares these detectors against the `GuardrailsGenieSecretsDetector`
* `guardrails_genie/guardrails/secrets_detection/__init__.py`: Removed `DEFAULT_SECRETS_PATTERNS` and replaced `redact` with `redact_value` to streamline the secrets detection process.
* Upgraded the `GuardrailsGenieSecretsDetector` to use both `detect-secrets` and `hyperscan` further enhancing the precision of the detector.
### Dependency Updates:

* `pyproject.toml` Added new dependencies `numpy`, `gibberish-detector`, `detect-secrets`, and `hyperscan` to enhance the functionality of the project.

### Test Improvements:

* `tests/guardrails_genie/guardrails/test_secrets_detection.py` Updated tests to use `redact_value` instead of `redact`, and added risk score assertions. Modified the mock guard function to reflect changes in secrets detection responses. 
